### PR TITLE
Use placeholders for configuration files

### DIFF
--- a/Formula/malt.rb
+++ b/Formula/malt.rb
@@ -1,7 +1,7 @@
 class Malt < Formula
   desc "JSON-driven Homebrew Dev Services"
   homepage "https://github.com/koriym/homebrew-malt"
-  version "1.0.0beta5
+  version "1.0.0beta4"
   url "file:///dev/null"
 
   depends_on "jq"

--- a/Formula/malt.rb
+++ b/Formula/malt.rb
@@ -1,7 +1,7 @@
 class Malt < Formula
   desc "JSON-driven Homebrew Dev Services"
   homepage "https://github.com/koriym/homebrew-malt"
-  version "1.0.0beta3"
+  version "1.0.0beta5
   url "file:///dev/null"
 
   depends_on "jq"

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -260,7 +260,7 @@ module Malt
 
       if config.ports["httpd"]
         httpd_template = Malt::Template.new(File.join(templates_dir, "httpd", "httpd.conf.erb"))
-        php_lib_path = "#{HOMEBREW_PREFIX}/opt/php@#{config.php_version}/lib/httpd/modules/libphp.so"
+        php_lib_path = "{{HOMEBREW_PREFIX}}/opt/php@#{config.php_version}/lib/httpd/modules/libphp.so"
 
         config.ports["httpd"].each do |port|
           content = httpd_template.render({

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -248,7 +248,7 @@ module Malt
                                             PORT: port,
                                             MALT_DIR: "{{MALT_DIR}}",
                                             DOCUMENT_ROOT: "{{PUBLIC_DIR}}",
-                                            HOMEBREW_PREFIX: HOMEBREW_PREFIX,
+                                            HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
                                             PHP_PORT: config.ports["php"].first
                                           })
           File.write(File.join(config.malt_dir, "conf", "nginx_#{port}.conf"), content)
@@ -267,7 +267,7 @@ module Malt
                                             PORT: port,
                                             MALT_DIR: "{{MALT_DIR}}",
                                             DOCUMENT_ROOT: "{{PUBLIC_DIR}}",
-                                            HOMEBREW_PREFIX: HOMEBREW_PREFIX,
+                                            HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
                                             PHP_LIB_PATH: php_lib_path
                                           })
           File.write(File.join(config.malt_dir, "conf", "httpd_#{port}.conf"), content)

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -254,7 +254,7 @@ module Malt
           File.write(File.join(config.malt_dir, "conf", "nginx_#{port}.conf"), content)
         end
 
-        content = nginx_main_template.render({ HOMEBREW_PREFIX: HOMEBREW_PREFIX, NGINX_INCLUDES: 'abv' })
+        content = nginx_main_template.render({ HOMEBREW_PREFIX: HOMEBREW_PREFIX, NGINX_INCLUDES: nginx_includes })
         File.write(File.join(config.malt_dir, "conf", "nginx_main.conf"), content)
       end
 

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -254,7 +254,7 @@ module Malt
           File.write(File.join(config.malt_dir, "conf", "nginx_#{port}.conf"), content)
         end
 
-        content = nginx_main_template.render({ HOMEBREW_PREFIX: HOMEBREW_PREFIX, NGINX_INCLUDES: nginx_includes })
+        content = nginx_main_template.render({ HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}", NGINX_INCLUDES: nginx_includes })
         File.write(File.join(config.malt_dir, "conf", "nginx_main.conf"), content)
       end
 

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -242,7 +242,7 @@ module Malt
         nginx_template = Malt::Template.new(File.join(templates_dir, "nginx", "nginx.conf.erb"))
         nginx_main_template = Malt::Template.new(File.join(templates_dir, "nginx", "nginx_main.conf.erb"))
 
-        nginx_includes = config.ports["nginx"].map { |port| "include #{config.malt_dir}/conf/nginx_#{port}.conf;" }.join("\n  ")
+        nginx_includes = config.ports["nginx"].map { |port| "include {{MALT_DIR}}/conf/nginx_#{port}.conf;" }.join("\n  ")
         config.ports["nginx"].each do |port|
           content = nginx_template.render({
                                             PORT: port,
@@ -254,7 +254,7 @@ module Malt
           File.write(File.join(config.malt_dir, "conf", "nginx_#{port}.conf"), content)
         end
 
-        content = nginx_main_template.render({ HOMEBREW_PREFIX: HOMEBREW_PREFIX, NGINX_INCLUDES: nginx_includes })
+        content = nginx_main_template.render({ HOMEBREW_PREFIX: HOMEBREW_PREFIX, NGINX_INCLUDES: 'abv' })
         File.write(File.join(config.malt_dir, "conf", "nginx_main.conf"), content)
       end
 

--- a/share/templates/nginx/nginx_main.conf.erb
+++ b/share/templates/nginx/nginx_main.conf.erb
@@ -8,5 +8,6 @@ http {
   sendfile on;
   keepalive_timeout 65;
 
+  # Include the server configuration
   {{NGINX_INCLUDES}}
 }


### PR DESCRIPTION
Closes #3

Replaced direct references to `HOMEBREW_PREFIX` with placeholders ("{{HOMEBREW_PREFIX}}") in Nginx and HTTPD configuration file generation for improved flexibility and environment-specific value substitution.

## Sourceryによるサマリー

機能拡張:
- NginxとHTTPDの設定ファイル生成において、`HOMEBREW_PREFIX`への直接参照をプレースホルダーに置き換えました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replaces direct references to `HOMEBREW_PREFIX` with placeholders in Nginx and HTTPD configuration file generation.

</details>

## Sourcery によるサマリー

機能拡張:
- Nginx および HTTPD の設定ファイル生成において、`HOMEBREW_PREFIX` への直接参照をプレースホルダーに置き換えました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replaces direct references to `HOMEBREW_PREFIX` with placeholders in Nginx and HTTPD configuration file generation.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Bumped the core component version from 1.0.0beta3 to 1.0.0beta4.
  - Standardized configuration templates to use dynamic tokens for smoother adaptability.
- **Documentation**
  - Enhanced configuration files with descriptive annotations to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->