### PR TITLE
Update file extensions in nginx include paths

### DIFF
--- a/lib/project.rb
+++ b/lib/project.rb
@@ -242,7 +242,7 @@ module Malt
         nginx_template = Malt::Template.new(File.join(templates_dir, "nginx", "nginx.conf.erb"))
         nginx_main_template = Malt::Template.new(File.join(templates_dir, "nginx", "nginx_main.conf.erb"))
 
-        nginx_includes = config.ports["nginx"].map { |port| "include {{MALT_DIR}}/conf/nginx_#{port}.conf;" }.join("\n  ")
+        nginx_includes = config.ports["nginx"].map { |port| "include {{MALT_DIR}}/conf/nginx_#{port}.conf.tmp;" }.join("\n  ")
         config.ports["nginx"].each do |port|
           content = nginx_template.render({
                                             PORT: port,

--- a/lib/service_manager.rb
+++ b/lib/service_manager.rb
@@ -614,6 +614,11 @@ module Malt
             main_content = main_content.gsub(original_include, temp_include)
           end
 
+          # HOMEBREW_PREFIXの置換を追加
+          if main_content.include?("{{HOMEBREW_PREFIX}}")
+            main_content = main_content.gsub("{{HOMEBREW_PREFIX}}", HOMEBREW_PREFIX)
+          end
+
           # 修正したメイン設定内容を使って一時ファイルを作成
           temp_main_path = "#{nginx_conf}.tmp"
           File.write(temp_main_path, main_content)

--- a/share/templates/nginx/nginx_main.conf.erb
+++ b/share/templates/nginx/nginx_main.conf.erb
@@ -8,6 +8,5 @@ http {
   sendfile on;
   keepalive_timeout 65;
 
-  # Include the server configuration
   {{NGINX_INCLUDES}}
 }


### PR DESCRIPTION
- [x] Remove unnecessary comment above `{{NGINX_INCLUDES}}`.
- [x] Update file extensions in nginx include paths to `.conf.tmp` for clarity.

## Sourceryによるサマリー

Nginxの設定を更新し、インクルードパスに'.conf.tmp'のファイル拡張子を使用し、メインのNginx設定ファイル内のHOMEBREW_PREFIXプレースホルダーを置き換えます。

機能拡張:
- 明確にするため、nginxインクルードパスのファイル拡張子を'.conf.tmp'に更新します。
- メインのNginx設定ファイル内のHOMEBREW_PREFIXプレースホルダーを実際のHomebrewプレフィックスに置き換えます。
- `{{NGINX_INCLUDES}}`の上の不要なコメントを削除します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Updates Nginx configuration to use '.conf.tmp' file extensions for include paths and replaces the HOMEBREW_PREFIX placeholder in the main Nginx configuration file.

Enhancements:
- Updates file extensions in nginx include paths to '.conf.tmp' for clarity.
- Replaces the HOMEBREW_PREFIX placeholder in the main Nginx configuration file with the actual Homebrew prefix.
- Removes unnecessary comment above `{{NGINX_INCLUDES}}`.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic substitution for environment-specific values in webserver configurations.
- **Refactor**
  - Updated the naming convention for generated configuration files for streamlined processing.
- **Style**
  - Removed redundant commentary from configuration templates for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->