### PR TITLE
Add PHPComplete Homebrew formula and README

### DIFF
--- a/Formula/phpcomplete.rb
+++ b/Formula/phpcomplete.rb
@@ -32,6 +32,10 @@ class Phpcomplete < Formula
   depends_on "shivammathur/extensions/xdebug@8.3"
   depends_on "shivammathur/extensions/xdebug@8.4"
 
+  def install
+    (prefix/"INSTALLED").write "phpcomplete installation successful"
+  end
+
   test do
     assert_match "phpcomplete installation successful", shell_output("cat #{prefix}/INSTALLED")
   end

--- a/Formula/phpcomplete.rb
+++ b/Formula/phpcomplete.rb
@@ -1,0 +1,36 @@
+class Phpcomplete < Formula
+  desc "Install multiple versions of PHP with XDebug and other PECL packages"
+  homepage "https://www.php.net/"
+  version "0.1.0"
+  url "file:///dev/null"
+  sha256 ""
+  license "MIT"
+
+  # Please comment out any unnecessary PHP versions.
+  depends_on "shivammathur/php/php@5.6"
+  depends_on "shivammathur/php/php@7.0"
+  depends_on "shivammathur/php/php@7.1"
+  depends_on "shivammathur/php/php@7.2"
+  depends_on "shivammathur/php/php@7.3"
+  depends_on "shivammathur/php/php@7.4"
+  depends_on "shivammathur/php/php@8.0"
+  depends_on "shivammathur/php/php@8.1"
+  depends_on "shivammathur/php/php@8.2"
+  depends_on "shivammathur/php/php@8.3"
+  depends_on "shivammathur/php/php@8.4"
+  depends_on "shivammathur/extensions/xdebug@5.6"
+  depends_on "shivammathur/extensions/xdebug@7.0"
+  depends_on "shivammathur/extensions/xdebug@7.1"
+  depends_on "shivammathur/extensions/xdebug@7.2"
+  depends_on "shivammathur/extensions/xdebug@7.3"
+  depends_on "shivammathur/extensions/xdebug@7.4"
+  depends_on "shivammathur/extensions/xdebug@8.0"
+  depends_on "shivammathur/extensions/xdebug@8.1"
+  depends_on "shivammathur/extensions/xdebug@8.2"
+  depends_on "shivammathur/extensions/xdebug@8.3"
+  depends_on "shivammathur/extensions/xdebug@8.4"
+
+  test do
+    assert_match "phpcomplete installation successful", shell_output("cat #{prefix}/INSTALLED")
+  end
+end

--- a/Formula/phpcomplete.rb
+++ b/Formula/phpcomplete.rb
@@ -1,5 +1,5 @@
 class Phpcomplete < Formula
-  desc "Install multiple versions of PHP with XDebug and other PECL packages"
+  desc "Install multiple versions of PHP with XDebug"
   homepage "https://www.php.net/"
   version "0.1.0"
   url "file:///dev/null"
@@ -18,6 +18,8 @@ class Phpcomplete < Formula
   depends_on "shivammathur/php/php@8.2"
   depends_on "shivammathur/php/php@8.3"
   depends_on "shivammathur/php/php@8.4"
+
+  # See full list here: https://github.com/shivammathur/homebrew-extensions
   depends_on "shivammathur/extensions/xdebug@5.6"
   depends_on "shivammathur/extensions/xdebug@7.0"
   depends_on "shivammathur/extensions/xdebug@7.1"

--- a/Formula/phpcomplete.rb
+++ b/Formula/phpcomplete.rb
@@ -36,6 +36,37 @@ class Phpcomplete < Formula
     (prefix/"INSTALLED").write "phpcomplete installation successful"
   end
 
+  def caveats
+    <<~EOS
+  Multiple PHP versions have been installed. To use a specific version, you can:
+
+  1. Create shell aliases (add to your .bashrc or .zshrc):
+     ```shell
+     alias php56='export PATH="/opt/homebrew/opt/php@5.6/bin:$PATH" && echo "Switched to PHP 5.6"'
+     alias php70='export PATH="/opt/homebrew/opt/php@7.0/bin:$PATH" && echo "Switched to PHP 7.0"'
+     alias php71='export PATH="/opt/homebrew/opt/php@7.1/bin:$PATH" && echo "Switched to PHP 7.1"'
+     alias php72='export PATH="/opt/homebrew/opt/php@7.2/bin:$PATH" && echo "Switched to PHP 7.2"'
+     alias php73='export PATH="/opt/homebrew/opt/php@7.3/bin:$PATH" && echo "Switched to PHP 7.3"'
+     alias php74='export PATH="/opt/homebrew/opt/php@7.4/bin:$PATH" && echo "Switched to PHP 7.4"'
+     alias php80='export PATH="/opt/homebrew/opt/php@8.0/bin:$PATH" && echo "Switched to PHP 8.0"'
+     alias php81='export PATH="/opt/homebrew/opt/php@8.1/bin:$PATH" && echo "Switched to PHP 8.1"'
+     alias php82='export PATH="/opt/homebrew/opt/php@8.2/bin:$PATH" && echo "Switched to PHP 8.2"'
+     alias php83='export PATH="/opt/homebrew/opt/php@8.3/bin:$PATH" && echo "Switched to PHP 8.3"'
+     alias php84='export PATH="/opt/homebrew/opt/php@8.4/bin:$PATH" && echo "Switched to PHP 8.4"'
+     ```
+
+  2. Use version switcher commands:
+     php8.2
+     php -v   # Now using PHP 8.2
+     
+     php7.4
+     php -v   # Now using PHP 7.4
+
+  For more detailed instructions, see:
+  https://github.com/koriym/homebrew-malt/phpcpmplete/
+  EOS
+  end
+
   test do
     assert_match "phpcomplete installation successful", shell_output("cat #{prefix}/INSTALLED")
   end

--- a/README-phpcomplete.md
+++ b/README-phpcomplete.md
@@ -1,0 +1,115 @@
+# PHP Complete
+
+PHP Complete is a Homebrew formula that allows you to install multiple versions of PHP, along with Xdebug and other popular PECL packages. It simplifies the process of setting up a comprehensive PHP development environment.
+
+## Features
+
+- Installs multiple PHP versions (`5.6` to `8.4`) using the shivammathur/php tap
+- Installs Xdebug for all PHP versions
+- Provides a convenient way to manage PHP extensions and dependencies
+
+## Requirements
+
+- [Homebrew](https://brew.sh/)
+
+## Installation
+
+```shell
+brew install koriym/malt/phpcomplete
+```
+
+This command will install the specified PHP versions, Xdebug, and the additional PECL packages defined in the formula.
+
+## Customization
+
+You can customize the PHP versions and extensions installed by PHP Complete by modifying the formula file.
+
+```shell
+brew edit phpcompelete
+```
+
+When you have finished editing, reinstall to reflect the changes.
+
+```shell
+brew reinstall phpcomplete
+```
+
+## Switching PHP Versions using Aliases
+
+To switch between different PHP versions without using additional tools or modifying terminal profiles, you can set up aliases in your shell's initialization file (~/.bashrc or ~/.zshrc). This approach allows you to quickly switch PHP versions by executing simple commands.
+
+### Step 1: Edit Shell Initialization File
+
+Add the following aliases to your shell's initialization file:
+
+```shell
+# ~/.bashrc or ~/.zshrc
+
+# PHP version switcher aliases
+alias php56='export PATH="/opt/homebrew/opt/php@5.6/bin:$PATH" && export PATH="/opt/homebrew/opt/php@5.6/sbin:$PATH"'
+alias php70='export PATH="/opt/homebrew/opt/php@7.0/bin:$PATH" && export PATH="/opt/homebrew/opt/php@7.0/sbin:$PATH"'
+alias php71='export PATH="/opt/homebrew/opt/php@7.1/bin:$PATH" && export PATH="/opt/homebrew/opt/php@7.1/sbin:$PATH"'
+alias php72='export PATH="/opt/homebrew/opt/php@7.2/bin:$PATH" && export PATH="/opt/homebrew/opt/php@7.2/sbin:$PATH"'
+alias php73='export PATH="/opt/homebrew/opt/php@7.3/bin:$PATH" && export PATH="/opt/homebrew/opt/php@7.3/sbin:$PATH"'
+alias php74='export PATH="/opt/homebrew/opt/php@7.4/bin:$PATH" && export PATH="/opt/homebrew/opt/php@7.4/sbin:$PATH"'
+alias php80='export PATH="/opt/homebrew/opt/php@8.0/bin:$PATH" && export PATH="/opt/homebrew/opt/php@8.0/sbin:$PATH"'
+alias php81='export PATH="/opt/homebrew/opt/php@8.1/bin:$PATH" && export PATH="/opt/homebrew/opt/php@8.1/sbin:$PATH"'
+alias php82='export PATH="/opt/homebrew/opt/php@8.2/bin:$PATH" && export PATH="/opt/homebrew/opt/php@8.2/sbin:$PATH"'
+alias php83='export PATH="/opt/homebrew/opt/php@8.3/bin:$PATH" && export PATH="/opt/homebrew/opt/php@8.3/sbin:$PATH"'
+alias php84='export PATH="/opt/homebrew/opt/php@8.4/bin:$PATH" && export PATH="/opt/homebrew/opt/php@8.4/sbin:$PATH"'
+```
+
+### Step 2: Reload Shell
+
+Reload your shell to apply the changes:
+
+```shell
+. ~/.bashrc  # or . ~/.zshrc
+```
+### Step 3: Switch PHP Versions
+
+You can now switch between PHP versions by using the aliases:
+
+```shell
+php81  # Switch to PHP 8.1
+php74  # Switch to PHP 7.4
+```
+
+### Benefits
+
+- **Simple and intuitive**: Quickly switch PHP versions with straightforward commands.
+- **No additional tools needed**: Uses only shell features, no need for extra software.
+
+## Switching PHP Versions using Terminal Profiles
+
+Alternatively, you can use terminal profiles to manage different PHP versions, providing a clear and organized way to work with multiple PHP versions simultaneously.
+
+### Step 1: Open Terminal Preferences
+
+1. Open the terminal's preferences.
+2. Select the "Profiles" tab.
+3. Click the "+" button to create a new profile.
+4. Give the profile a name (e.g., "PHP 8.1").
+
+### Step 2: Set Command
+
+In the "Shell" section, select "Command" and enter the following:
+
+```shell
+export PATH="/opt/homebrew/opt/php@8.1/bin:$PATH"
+```
+You can also change the title to `PHP 8.1` in the Window tab.
+
+### Step 4: Save the Profile
+
+Save the profile. Now, whenever you want to use a specific PHP version, you can open a new terminal window or tab and select the corresponding profile from the dropdown menu.
+
+## Benefits
+
+Clear version indication: Each terminal window/tab can be set to a specific PHP version, making it easy to see which version is in use.
+Simultaneous use: Allows multiple terminal windows/tabs with different PHP versions open at the same time.
+
+## Conclusion
+
+Both methods offer effective ways to manage multiple PHP versions without relying on additional software or utilities. The alias method is quick and easy to set up, ideal for those who prefer simplicity. The terminal profile method provides better organization and clarity when working with multiple versions simultaneously. Choose the method that best fits your workflow and preferences.
+

--- a/README-phpcomplete.md
+++ b/README-phpcomplete.md
@@ -25,7 +25,7 @@ This command will install the specified PHP versions, Xdebug, and the additional
 You can customize the PHP versions and extensions installed by PHP Complete by modifying the formula file.
 
 ```shell
-brew edit phpcompelete
+brew edit phpcomplete
 ```
 
 When you have finished editing, reinstall to reflect the changes.

--- a/README.ja.md
+++ b/README.ja.md
@@ -294,7 +294,7 @@ Devbox.jsonは以下に適しているかもしれません：
 
 どちらのツールもクロスプラットフォームで宣言的な設定を提供します。
 
-#### 🍺Malt Prompt Brewery
+## 🍺Malt Prompt Brewery
 
 [Malt Prompt Brewery](https://koriym.github.io/homebrew-malt/prompt.html)を使用して、malt.jsonからインフラストラクチャコードを生成します。
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Devbox.json may be better for:
 
 Both tools are cross-platform and offer declarative configuration.
 
-#### 🍺Malt Prompt Brewery
+## 🍺Malt Prompt Brewery
 
 Brew infrastructure code from your malt.json using our [Malt Prompt Brewery](https://koriym.github.io/homebrew-malt/prompt.html).
 

--- a/phpcomplete/README.md
+++ b/phpcomplete/README.md
@@ -66,6 +66,8 @@ Reload your shell to apply the changes:
 ```shell
 . ~/.bashrc  # or . ~/.zshrc
 ```
+- Note: These instructions apply to macOS Terminal.app. For other terminal applications like iTerm2, the process may be slightly different but follows similar principles.
+
 ### Step 3: Switch PHP Versions
 
 You can now switch between PHP versions by using the aliases:
@@ -106,8 +108,10 @@ Save the profile. Now, whenever you want to use a specific PHP version, you can 
 
 ## Benefits
 
-Clear version indication: Each terminal window/tab can be set to a specific PHP version, making it easy to see which version is in use.
-Simultaneous use: Allows multiple terminal windows/tabs with different PHP versions open at the same time.
+- **Clear version indication**: Each terminal window/tab can be set to a specific PHP version, making it easy to see which version is in use.
+- **Simultaneous use**: Allows multiple terminal windows/tabs with different PHP versions open at the same time.
+- **Clear version indication**: Each terminal window/tab can be set to a specific PHP version, making it easy to see which version is in use.
+- **Simultaneous use**: Allows multiple terminal windows/tabs with different PHP versions open at the same time.
 
 ## Conclusion
 


### PR DESCRIPTION
**Description:**
- Update PHPComplete formula description for clarity.
- Add link to full list of available extensions.
- Introduce PHPComplete formula for managing PHP versions.
- Install PHP versions 5.6 to 8.4 with XDebug and PECL extensions.
- Include detailed README with usage instructions and customization options.
- Provide methods for switching between PHP versions using shell aliases or terminal profiles.

## Sourceryによる概要

Homebrew formula、PHPCompleteを導入し、Xdebugとともに複数のPHPバージョン（5.6から8.4）のインストールと管理を容易にします。また、READMEファイルには、formulaの使用方法や、シェルエイリアスまたはターミナルプロファイルを使用してPHPバージョンを切り替える方法が記載されています。

新機能：
- Xdebugとともに複数のPHPバージョンをインストールおよび管理するためのHomebrew formulaを導入します。
- READMEファイルに、シェルエイリアスまたはターミナルプロファイルを使用してPHPバージョンを切り替えるための手順を記載します。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduces a Homebrew formula, PHPComplete, to facilitate the installation and management of multiple PHP versions (5.6 to 8.4) along with Xdebug. It also includes a README file with instructions on how to use the formula and switch between PHP versions using shell aliases or terminal profiles.

New Features:
- Introduces a Homebrew formula to install and manage multiple PHP versions with Xdebug.
- Provides instructions for switching PHP versions using shell aliases or terminal profiles in the README file.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a Homebrew formula that streamlines the installation of multiple PHP versions (5.6 to 8.4) along with PHP extensions.

- **Documentation**
  - Added a comprehensive guide detailing setup instructions, including how to configure shell aliases and alternate methods for seamless PHP version switching.
  - Updated the visual hierarchy of the "Malt Prompt Brewery" section in the README files for better prominence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->