### PR TITLE
Add handling for temporary PHP.ini configuration files

### DIFF
--- a/lib/service_manager.rb
+++ b/lib/service_manager.rb
@@ -454,8 +454,9 @@ module Malt
           return
         end
 
-        # Create temporary config file with variable expansion
+        # Create temporary config files with variable expansion
         temp_conf = create_temp_config(config, php_fpm_conf)
+        temp_ini = create_temp_config(config, php_ini)
 
         # Error if temporary file creation failed
         if temp_conf.nil?
@@ -463,10 +464,16 @@ module Malt
           return
         end
 
-        puts "Using PHP-FPM config file: #{temp_conf}"
+        if temp_ini.nil?
+          puts "Error: Failed to create temporary config file for PHP.ini"
+          return
+        end
 
-        # Start using temporary file
-        cmd = "#{HOMEBREW_PREFIX}/opt/php@#{config.php_version}/sbin/php-fpm -y #{temp_conf} -c #{php_ini}"
+        puts "Using PHP-FPM config file: #{temp_conf}"
+        puts "Using PHP.ini file: #{temp_ini}"
+
+        # Start using temporary files
+        cmd = "#{HOMEBREW_PREFIX}/opt/php@#{config.php_version}/sbin/php-fpm -y #{temp_conf} -c #{temp_ini}"
         system("#{cmd} &")
       end
 
@@ -480,6 +487,13 @@ module Malt
             Dir.glob(File.join(Dir.pwd, "malt", "conf", "php-fpm_*.conf.tmp")).each do |tmp_file|
               puts "Cleaning up temporary file: #{tmp_file}" if ENV["MALT_DEBUG"]
               FileUtils.rm(tmp_file) if File.exist?(tmp_file) && !ENV["MALT_DEBUG"]
+            end
+            
+            # Clean up php.ini temporary file
+            php_ini_tmp = File.join(Dir.pwd, "malt", "conf", "php.ini.tmp")
+            if File.exist?(php_ini_tmp)
+              puts "Cleaning up temporary file: #{php_ini_tmp}" if ENV["MALT_DEBUG"]
+              FileUtils.rm(php_ini_tmp) unless ENV["MALT_DEBUG"]
             end
           end
         else


### PR DESCRIPTION
<details>
<summary>Details</summary>

Introduce creation, usage, and cleanup of temporary PHP.ini files alongside PHP-FPM config files. This ensures proper isolation during execution and avoids potential conflicts with existing configurations.

- [ ] Implement logic for creating temporary PHP.ini files
- [ ] Incorporate temporary PHP.ini files in PHP-FPM configuration handling
- [ ] Add cleanup functionality for temporary PHP.ini files after usage

</details>

## Sourcery によるサマリー

雑務：
- 使用後の一時的な PHP.ini ファイルをクリーンアップする機能を追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Add cleanup functionality for temporary PHP.ini files after usage.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced PHP service reliability with streamlined configuration handling during startup.
	- Introduced improved error reporting for configuration issues.
	- Ensured proper cleanup during service shutdown for more robust operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->