### PR TITLE
Add directory check for 'malt start' command

### DIFF
--- a/bin/malt.rb
+++ b/bin/malt.rb
@@ -108,8 +108,8 @@ begin
 
     # Check if the malt directory exists
     unless Dir.exist?(malt_dir_path)
-      puts "Warning: Malt directory '#{malt_dir_path}' not found."
-      puts "Please run 'malt create' first to generate configuration files."
+      warn "Warning: Malt directory '#{malt_dir_path}' not found."
+      warn "Please run 'malt create' first to generate configuration files."
       exit 1 # Exit with a non-zero status
     end
 

--- a/bin/malt.rb
+++ b/bin/malt.rb
@@ -103,6 +103,17 @@ begin
   when "create"
     Malt::Project.create(options)
   when "start"
+    # Determine the expected malt directory path based on the current directory
+    malt_dir_path = File.join(Dir.pwd, 'malt')
+
+    # Check if the malt directory exists
+    unless Dir.exist?(malt_dir_path)
+      puts "Warning: Malt directory '#{malt_dir_path}' not found."
+      puts "Please run 'malt create' first to generate configuration files."
+      exit 1 # Exit with a non-zero status
+    end
+
+    # If the directory exists, proceed with starting services
     Malt::ServiceManager.start(options)
   when "stop"
     Malt::ServiceManager.stop(options)

--- a/bin/malt.rb
+++ b/bin/malt.rb
@@ -109,7 +109,7 @@ begin
     # Check if the malt directory exists
     unless Dir.exist?(malt_dir_path)
       warn "Warning: Malt directory '#{malt_dir_path}' not found."
-      warn "Please run 'malt create' first to generate configuration files."
+      warn "Please run `malt create` first to generate configuration files."
       exit 1 # Exit with a non-zero status
     end
 


### PR DESCRIPTION
### Description

This pull request introduces a validation step to ensure the required `malt` directory exists before executing the `malt start` command. If the directory is missing, the user will receive a warning, and the program will terminate with a non-zero status. This change aims to guide users to create the required setup before proceeding, avoiding unexpected

## Sourceryによるサマリー

'malt start' コマンドにディレクトリの検証を追加し、適切なプロジェクト設定を保証します。

新機能:
- startコマンド実行前に、'malt'ディレクトリの存在を検証する事前実行チェックを実装

バグ修正:
- プロジェクトが適切に初期化されていない場合に、実行を停止して予期しない動作を防ぎます。

機能拡張:
- 必要なディレクトリが見つからない場合に、ユーザーフレンドリーな警告メッセージを追加

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add directory validation for 'malt start' command to ensure proper project setup

New Features:
- Implement a pre-execution check to validate the existence of the 'malt' directory before running the start command

Bug Fixes:
- Prevent unexpected behavior by stopping execution if the project is not properly initialized

Enhancements:
- Add user-friendly warning message when the required directory is missing

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation for the "start" command to ensure the required configuration directory exists before starting services. Users will receive a warning to run the "malt create" command if the directory is missing, preventing unexpected startup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->