### PR TITLE
Set dynamic public_dir and improve directory validation

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -58,8 +58,8 @@ module Malt
     end
 
     def document_root
-      # Use the fixed "public" directory, resolved as a relative path from project_dir
-      File.join(@project_dir, "public")
+      # Use the @public_dir value read from config or default "public"
+      File.join(@project_dir, @public_dir)
     end
 
     def validate!

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -247,7 +247,6 @@ module Malt
           content = nginx_template.render({
                                             PORT: port,
                                             MALT_DIR: "{{MALT_DIR}}",
-                                            DOCUMENT_ROOT: "{{PUBLIC_DIR}}",
                                             HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
                                             PHP_PORT: config.ports["php"].first
                                           })
@@ -266,7 +265,7 @@ module Malt
           content = httpd_template.render({
                                             PORT: port,
                                             MALT_DIR: "{{MALT_DIR}}",
-                                            DOCUMENT_ROOT: "{{PUBLIC_DIR}}",
+                                            # DOCUMENT_ROOT: "{{PUBLIC_DIR}}", # Removed unused context
                                             HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
                                             PHP_LIB_PATH: php_lib_path
                                           })

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -265,7 +265,6 @@ module Malt
           content = httpd_template.render({
                                             PORT: port,
                                             MALT_DIR: "{{MALT_DIR}}",
-                                            # DOCUMENT_ROOT: "{{PUBLIC_DIR}}", # Removed unused context
                                             HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
                                             PHP_LIB_PATH: php_lib_path
                                           })

--- a/lib/service_manager.rb
+++ b/lib/service_manager.rb
@@ -326,7 +326,6 @@ module Malt
         template_vars = {
           "MALT_DIR" => config.malt_dir,
           "PROJECT_DIR" => config.project_dir,
-          "PUBLIC_DIR" => config.document_root,
           "PHP_VERSION" => config.php_version,
           "HOMEBREW_PREFIX" => HOMEBREW_PREFIX
         }

--- a/lib/service_manager.rb
+++ b/lib/service_manager.rb
@@ -326,8 +326,7 @@ module Malt
         template_vars = {
           "MALT_DIR" => config.malt_dir,
           "PROJECT_DIR" => config.project_dir,
-          "DOCUMENT_ROOT" => config.document_root,
-          "PUBLIC_DIR" => config.document_root,
+          "PUBLIC_DIR" => config.document_root, # Re-added for placeholder replacement
           "PHP_VERSION" => config.php_version,
           "HOMEBREW_PREFIX" => HOMEBREW_PREFIX
         }

--- a/lib/service_manager.rb
+++ b/lib/service_manager.rb
@@ -326,7 +326,7 @@ module Malt
         template_vars = {
           "MALT_DIR" => config.malt_dir,
           "PROJECT_DIR" => config.project_dir,
-          "PUBLIC_DIR" => config.document_root, # Re-added for placeholder replacement
+          "PUBLIC_DIR" => config.document_root,
           "PHP_VERSION" => config.php_version,
           "HOMEBREW_PREFIX" => HOMEBREW_PREFIX
         }


### PR DESCRIPTION
### Description

This pull request includes the following updates:
- Replaced hardcoded "public" directory with a dynamic `@public_dir` configuration for improved flexibility.
- Enhanced warning message formatting for `malt` directory checks, using backticks for consistent inline code references.
- Added validation to ensure the required `malt` directory exists when running the `malt start` command. Missing directories prompt a warning and exit with a non-zero status.
- Minor updates to `bin/malt.rb`, co-authored with sourcery-ai[bot]. 

These changes aim to enhance configurability, improve user guidance, and ensure consistent formatting practices.

## Sourceryによるサマリー

動的な公開ディレクトリの導入とディレクトリの検証の強化により、プロジェクト構成を改善します。

新機能：
- 公開ディレクトリの場所に関する動的な構成を追加
- 必須プロジェクトディレクトリの検証を実装

機能拡張：
- ハードコードされた 'public' ディレクトリを、構成可能な `@public_dir` 設定に置き換え
- ドキュメントルートをより柔軟にすることで、テンプレートのレンダリングを改善

雑務：
- 動的な公開ディレクトリ構成をサポートするために、構成とサービス管理を更新

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve project configuration by introducing a dynamic public directory and enhancing directory validation

New Features:
- Add dynamic configuration for public directory location
- Implement validation for required project directories

Enhancements:
- Replace hardcoded 'public' directory with a configurable @public_dir setting
- Improve template rendering by making document root more flexible

Chores:
- Update configuration and service management to support dynamic public directory configuration

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The public content directory is now configurable via settings, defaulting to "public" when not specified.
  
- **Chores**
  - Streamlined server configuration generation by removing outdated parameters.
  - Simplified temporary configuration processes with deprecated parameters eliminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->