### PR TITLE
Resolve PHP extension .so paths via Homebrew opt prefix

### DIFF
--- a/lib/project.rb
+++ b/lib/project.rb
@@ -88,7 +88,8 @@ module Malt
 
           json_data["php_extensions"].each do |ext|
             ext_lower = ext.downcase
-            formula_name = "#{ext_lower}@#{php_version}"
+            candidates = ["#{ext_lower}@#{php_version}", "php#{ext_lower}@#{php_version}", "php-#{ext_lower}@#{php_version}"]
+            formula_name = candidates.find { |name| installed_formulas.include?(name) } || candidates.first
             formula_installed = installed_formulas.include?(formula_name)
 
             if formula_installed
@@ -235,7 +236,10 @@ module Malt
       raise "Template file not found: #{php_ini_template_path}" unless File.exist?(php_ini_template_path)
 
       php_ini_template = Malt::Template.new(php_ini_template_path)
-      php_extensions = config.php_extensions.map { |ext| ext == "xdebug" ? "zend_extension=#{ext}.so" : "extension=#{ext}.so" }.join("\n")
+      php_extensions = config.php_extensions.map { |ext|
+        so_path = resolve_extension_path(ext, config.php_version)
+        ext == "xdebug" ? "zend_extension=#{so_path}" : "extension=#{so_path}"
+      }.join("\n")
       content = php_ini_template.render({ MALT_DIR: "{{MALT_DIR}}", PHP_EXTENSIONS: php_extensions })
       File.write(File.join(config.malt_dir, "conf", "php.ini"), content)
     end
@@ -309,6 +313,21 @@ module Malt
           content = memcached_template.render({ PORT: port, MALT_DIR: "{{MALT_DIR}}" })
           File.write(File.join(config.malt_dir, "conf", "memcached_#{port}.conf"), content)
         end
+      end
+    end
+
+    def self.resolve_extension_path(ext, php_version)
+      candidates = [
+        File.join(HOMEBREW_PREFIX, "opt", "#{ext}@#{php_version}", "#{ext}.so"),
+        File.join(HOMEBREW_PREFIX, "opt", "php#{ext}@#{php_version}", "#{ext}.so"),
+        File.join(HOMEBREW_PREFIX, "opt", "php-#{ext}@#{php_version}", "#{ext}.so"),
+      ]
+      found = candidates.find { |path| File.exist?(path) }
+      if found
+        found
+      else
+        puts "  Warning: Could not find #{ext}.so in Homebrew opt paths, using bare name"
+        "#{ext}.so"
       end
     end
   end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -237,8 +237,9 @@ module Malt
 
       php_ini_template = Malt::Template.new(php_ini_template_path)
       php_extensions = config.php_extensions.map { |ext|
-        so_path = resolve_extension_path(ext, config.php_version)
-        ext == "xdebug" ? "zend_extension=#{so_path}" : "extension=#{so_path}"
+        ext_lower = ext.downcase
+        so_path = resolve_extension_path(ext_lower, config.php_version)
+        ext_lower == "xdebug" ? "zend_extension=#{so_path}" : "extension=#{so_path}"
       }.join("\n")
       content = php_ini_template.render({ MALT_DIR: "{{MALT_DIR}}", PHP_EXTENSIONS: php_extensions })
       File.write(File.join(config.malt_dir, "conf", "php.ini"), content)

--- a/share/templates/php/php.ini.erb
+++ b/share/templates/php/php.ini.erb
@@ -3,3 +3,4 @@ error_log = "{{MALT_DIR}}/logs/php-error.log"
 sys_temp_dir = "{{MALT_DIR}}/tmp"
 upload_tmp_dir = "{{MALT_DIR}}/tmp"
 xdebug.output_dir = "{{MALT_DIR}}/tmp"
+{{PHP_EXTENSIONS}}


### PR DESCRIPTION
## Summary

- `php.ini.erb` に `{{PHP_EXTENSIONS}}` プレースホルダを追加。拡張ディレクティブが php.ini に書き出されるようにした
- `generate_php_configs` で拡張の .so パスを Homebrew opt ベースのフルパスで解決する `resolve_extension_path` メソッドを追加。`{ext}@{ver}`, `php{ext}@{ver}`, `php-{ext}@{ver}` の3パターンを探索
- `install_deps` の formula 名探索も同じ候補順序に統一

## Background

Homebrew formula でインストールした PHP 拡張は PHP の `extension_dir` に配置されないため、`extension=redis.so` のようなベアネームでは PHP がロードできない。`/opt/homebrew/opt/{formula}/{ext}.so` のフルパスが必要。

また formula 名の命名規則が統一されておらず（例: redis → `phpredis@8.4`）、複数パターンの探索が必要。

## Test

```bash
cd /path/to/project && rm -rf malt public
ruby /path/to/homebrew-malt/bin/malt.rb create
cat malt/conf/php.ini
```

```text
extension=/opt/homebrew/opt/phpredis@8.4/redis.so
extension=/opt/homebrew/opt/memcached@8.4/memcached.so
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced PHP extension discovery and configuration with improved support for multiple extension naming conventions and Homebrew paths.
  * PHP extensions can now be dynamically injected into configuration during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->