### PR TITLE
Rewrite SKILL.md and fix service stop race condition

### DIFF
--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -130,6 +130,21 @@ module Malt
       yield temp_conf
     end
 
+    # Wait for a process matching the pattern to terminate.
+    # Sends SIGKILL as a fallback if SIGTERM doesn't work within the timeout.
+    def wait_for_process_stop(pattern, timeout: 10)
+      timeout.times do
+        return unless system("pgrep -f #{pattern} >/dev/null 2>&1")
+        sleep 1
+      end
+
+      return unless system("pgrep -f #{pattern} >/dev/null 2>&1")
+
+      warn "Warning: #{pattern} still running after SIGTERM, sending SIGKILL..."
+      system("pkill -9 -f #{pattern}")
+      sleep 1
+    end
+
     # Remove temporary config file
     def remove_temp_config(temp_path)
       FileUtils.rm(temp_path) if File.exist?(temp_path)

--- a/lib/services/memcached_service.rb
+++ b/lib/services/memcached_service.rb
@@ -38,6 +38,7 @@ module Malt
       if system("pgrep -f memcached >/dev/null 2>&1")
         puts "Stopping Memcached..."
         system("pkill -f memcached")
+        wait_for_process_stop("memcached")
       else
         puts "[Stopped] Memcached is not running"
       end

--- a/lib/services/php_service.rb
+++ b/lib/services/php_service.rb
@@ -63,6 +63,7 @@ module Malt
       if system("pgrep -f php-fpm >/dev/null 2>&1")
         puts "Stopping PHP-FPM..."
         system("pkill -f php-fpm")
+        wait_for_process_stop("php-fpm")
 
         # Clean up temporary files
         if Dir.exist?(File.join(Dir.pwd, "malt", "conf"))


### PR DESCRIPTION
## Summary

- Rewrite SKILL.md as a concise reference guide, reducing verbosity while preserving all essential information
- Narrow MySQL detection in dependency handling to `ext-pdo_mysql` only
- Fix PHP-FPM and Memcached stop not waiting for process termination (Fixes #22)

## Test plan

- [ ] Verify `malt stop` waits for PHP-FPM to fully terminate before returning
- [ ] Verify Memcached stop also waits for process termination
- [ ] Confirm SIGKILL fallback triggers if SIGTERM doesn't work within 10 seconds
- [ ] Review SKILL.md for completeness and accuracy