### PR TITLE
Wait for process termination after pkill in service stop

### DIFF
--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -130,6 +130,21 @@ module Malt
       yield temp_conf
     end
 
+    # Wait for a process matching the pattern to terminate.
+    # Sends SIGKILL as a fallback if SIGTERM doesn't work within the timeout.
+    def wait_for_process_stop(pattern, timeout: 10)
+      timeout.times do
+        return unless system("pgrep -f #{pattern} >/dev/null 2>&1")
+        sleep 1
+      end
+
+      return unless system("pgrep -f #{pattern} >/dev/null 2>&1")
+
+      warn "Warning: #{pattern} still running after SIGTERM, sending SIGKILL..."
+      system("pkill -9 -f #{pattern}")
+      sleep 1
+    end
+
     # Remove temporary config file
     def remove_temp_config(temp_path)
       FileUtils.rm(temp_path) if File.exist?(temp_path)

--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -134,14 +134,14 @@ module Malt
     # Sends SIGKILL as a fallback if SIGTERM doesn't work within the timeout.
     def wait_for_process_stop(pattern, timeout: 10)
       timeout.times do
-        return unless system("pgrep -f #{pattern} >/dev/null 2>&1")
+        return unless system("pgrep", "-f", pattern, out: File::NULL, err: File::NULL)
         sleep 1
       end
 
-      return unless system("pgrep -f #{pattern} >/dev/null 2>&1")
+      return unless system("pgrep", "-f", pattern, out: File::NULL, err: File::NULL)
 
       warn "Warning: #{pattern} still running after SIGTERM, sending SIGKILL..."
-      system("pkill -9 -f #{pattern}")
+      system("pkill", "-9", "-f", pattern, out: File::NULL, err: File::NULL)
       sleep 1
     end
 

--- a/lib/services/memcached_service.rb
+++ b/lib/services/memcached_service.rb
@@ -35,9 +35,9 @@ module Malt
 
     def stop_memcached
       # Check if Memcached is running
-      if system("pgrep -f memcached >/dev/null 2>&1")
+      if system("pgrep", "-f", "memcached", out: File::NULL, err: File::NULL)
         puts "Stopping Memcached..."
-        system("pkill -f memcached")
+        system("pkill", "-f", "memcached", out: File::NULL, err: File::NULL)
         wait_for_process_stop("memcached")
       else
         puts "[Stopped] Memcached is not running"

--- a/lib/services/memcached_service.rb
+++ b/lib/services/memcached_service.rb
@@ -38,6 +38,7 @@ module Malt
       if system("pgrep -f memcached >/dev/null 2>&1")
         puts "Stopping Memcached..."
         system("pkill -f memcached")
+        wait_for_process_stop("memcached")
       else
         puts "[Stopped] Memcached is not running"
       end

--- a/lib/services/php_service.rb
+++ b/lib/services/php_service.rb
@@ -63,6 +63,7 @@ module Malt
       if system("pgrep -f php-fpm >/dev/null 2>&1")
         puts "Stopping PHP-FPM..."
         system("pkill -f php-fpm")
+        wait_for_process_stop("php-fpm")
 
         # Clean up temporary files
         if Dir.exist?(File.join(Dir.pwd, "malt", "conf"))

--- a/lib/services/php_service.rb
+++ b/lib/services/php_service.rb
@@ -60,9 +60,9 @@ module Malt
     end
 
     def stop_php_fpm
-      if system("pgrep -f php-fpm >/dev/null 2>&1")
+      if system("pgrep", "-f", "php-fpm", out: File::NULL, err: File::NULL)
         puts "Stopping PHP-FPM..."
-        system("pkill -f php-fpm")
+        system("pkill", "-f", "php-fpm", out: File::NULL, err: File::NULL)
         wait_for_process_stop("php-fpm")
 
         # Clean up temporary files


### PR DESCRIPTION
## Summary

- Add `wait_for_process_stop` helper to BaseService that polls for up to 10 seconds after SIGTERM, falling back to SIGKILL
- Apply to PHP-FPM and Memcached stop methods which used `pkill` without waiting for termination

Fixes #22

## Test plan

- [ ] Verify `malt stop` waits for PHP-FPM to fully terminate before returning
- [ ] Verify Memcached stop also waits for process termination
- [ ] Confirm SIGKILL fallback triggers if SIGTERM doesn't work within 10 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service shutdown reliability for Memcached and PHP-FPM by ensuring processes are fully stopped before cleanup, reducing race conditions and making teardowns more predictable.
* **Chores**
  * Added internal process-waiting and safer termination handling to support more robust shutdowns (no user-facing API changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->