### PR TITLE
skill(malt): check malt/ directory exists before malt start

### DIFF
--- a/skills/malt/SKILL.md
+++ b/skills/malt/SKILL.md
@@ -89,13 +89,20 @@ malt start             # 4. Start all configured services
 source <(malt env)     # 5. Set up PATH, env vars, and aliases
 ```
 
+Step 3 (`malt create`) is required, not optional. `malt start` reads configs from `malt/` and fails with "Malt directory not found" if the directory does not exist. Before invoking `malt start`, verify `malt/` is present and run `malt create` first if it is missing.
+
 ## Joining Existing Project
 
-For projects with `malt.json` already committed:
+For projects with `malt.json` already committed, the `malt/` directory may or may not be present. `malt.json` is committed, but `malt/` is often regenerated per-checkout. Always check before starting:
 
 ```bash
-malt install && malt start && source <(malt env)
+malt install
+[ -d malt ] || malt create
+malt start
+source <(malt env)
 ```
+
+Precondition: `malt start` requires the `malt/` directory. If only `malt.json` is present, run `malt create` first; otherwise `malt start` will fail with "Malt directory not found".
 
 ## malt.json Schema
 
@@ -138,6 +145,18 @@ All fields are required. Schema: `docs/schema.json`
 | `php_extensions` | string[] | PHP extensions to install via `shivammathur/extensions` tap |
 
 ## Troubleshooting Guide
+
+### Detecting State: `malt.json` Exists but `malt/` Does Not
+
+Common on a fresh checkout: the project commits `malt.json` but `malt/` is gitignored or has never been generated. Running `malt start` in this state fails with "Malt directory not found".
+
+Correct response:
+
+```bash
+malt create && malt start
+```
+
+Not `malt start` alone. The skill should test for `malt/` (e.g. `[ -d malt ]`) before invoking `malt start` and run `malt create` when the directory is absent.
 
 ### Port Already in Use
 


### PR DESCRIPTION
## Gap

The malt skill (`skills/malt/SKILL.md`) assumes the `malt/` directory exists whenever `malt.json` does. Two places encode this assumption:

- **Setup Flow** lists `malt create` as step 3 and `malt start` as step 4, but does not say step 3 is mandatory before step 4.
- **Joining Existing Project** suggests `malt install && malt start && source <(malt env)` with no `malt create` between install and start.

On a fresh checkout where `malt.json` is committed but `malt/` is gitignored (or has never been generated by anyone), the suggested commands fail.

## Failure mode

```text
$ malt start
Malt directory not found
```

`malt start` reads templates from `malt/conf/`. If the directory was never generated, there is nothing to start. This was hit in a real BEAR.Sunday CMS setup session: the user had committed `malt.json` but `malt/` had never been created, the skill drove `malt start` directly, and the user had to correct the model.

## Fix

Surgical edits to `skills/malt/SKILL.md`:

- Setup Flow: add a note after the command block stating step 3 (`malt create`) is required and that the skill must verify `malt/` exists before invoking `malt start`.
- Joining Existing Project: replace the one-liner with `malt install` + `[ -d malt ] || malt create` + `malt start` + `source <(malt env)`, plus an explicit precondition note.
- Troubleshooting: add a "Detecting State: `malt.json` Exists but `malt/` Does Not" entry that prescribes `malt create && malt start` (not `malt start` alone).

## Test plan

- [ ] Read the diff in `skills/malt/SKILL.md` and confirm voice/format matches the rest of the file.
- [ ] In a directory containing only `malt.json` (no `malt/`), follow the new "Joining Existing Project" snippet end-to-end and confirm services start.
- [ ] In the same scenario, confirm the old snippet (`malt install && malt start && source <(malt env)`) still reproduces "Malt directory not found", proving the precondition exists and is now documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the Malt workflow by explicitly documenting initialization prerequisites and the complete sequence of required steps before starting services
  * Updated project setup documentation with refined guidance for configuration procedures and service startup sequences
  * Added a comprehensive troubleshooting section providing step-by-step remediation instructions for resolving common configuration and initialization issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->