### PR TITLE
Scope malt kill to a pid registry instead of pattern-matching pkill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@ Config generation happens in two phases:
 - Port-in-use check: `lsof` on macOS, `ss` on Linux.
 - Status/kill are pid-file based, not port based: each service exposes `running?(config, port, index)` (pid file + process identity via `ps`). `malt status` reports `running` / `stopped` / `external process on port` (foreign process holding the port).
 - Global pid registry: every service start records pids in `HOMEBREW_PREFIX/var/malt/pids/` (override with `MALT_REGISTRY_DIR`). `malt kill` only SIGKILLs registry pids whose live command line still matches the identity recorded at start, so it can never kill Homebrew-managed services. Never reintroduce `pkill -f` on bare process names.
-- Service daemons are spawned with stdout/stderr redirected to files in `malt/logs/` (keeps `malt start | ...` pipes closable).
+- Non-daemonizing services (mysqld_safe, php-fpm `-y`, redis-server, httpd) are spawned via `Process.spawn` with stdout/stderr redirected to files in `malt/logs/` (keeps `malt start | ...` pipes closable). Nginx (`daemon on`) and Memcached (`-d`) fork themselves and are launched with `system` instead.
+- Web server configs are PHP-conditional: `nginx-static.conf.erb`/`httpd-static.conf.erb` are used instead of the PHP-serving templates when `php` has no ports, so `fastcgi_pass`/`LoadModule php_module` are never emitted for a PHP-free project.
 - Multiple instances of a service run on different ports (e.g., `"php": [9000, 9001]`).
 - Nginx uses a main config (`nginx_main.conf`) that includes per-port `.conf.tmp` files.
 - MySQL requires data directory initialization on first start (`--initialize-insecure`). Each MySQL instance gets its own data dir `malt/var/mysql_{index}/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ Config generation happens in two phases:
 - Port-in-use check: `lsof` on macOS, `ss` on Linux.
 - Status/kill are pid-file based, not port based: each service exposes `running?(config, port, index)` (pid file + process identity via `ps`). `malt status` reports `running` / `stopped` / `external process on port` (foreign process holding the port).
 - Global pid registry: every service start records pids in `HOMEBREW_PREFIX/var/malt/pids/` (override with `MALT_REGISTRY_DIR`). `malt kill` only SIGKILLs registry pids whose live command line still matches the identity recorded at start, so it can never kill Homebrew-managed services. Never reintroduce `pkill -f` on bare process names.
-- Service daemons are spawned with stdout/stderr redirected to files in `malt/logs/` (keeps `malt start | ...` pipes closable).
+- Non-daemonizing services (mysqld_safe, php-fpm `-y`, redis-server, httpd) are spawned via `Process.spawn` with stdout/stderr redirected to files in `malt/logs/` (keeps `malt start | ...` pipes closable). Nginx (`daemon on`) and Memcached (`-d`) fork themselves and are launched with `system` instead.
+- Web server configs are PHP-conditional: `nginx-static.conf.erb`/`httpd-static.conf.erb` are used instead of the PHP-serving templates when `php` has no ports, so `fastcgi_pass`/`LoadModule php_module` are never emitted for a PHP-free project.
 - Multiple instances of a service run on different ports (e.g., `"php": [9000, 9001]`).
 - Nginx uses a main config (`nginx_main.conf`) that includes per-port `.conf.tmp` files.
 - MySQL requires data directory initialization on first start (`--initialize-insecure`). Each MySQL instance gets its own data dir `malt/var/mysql_{index}/`.

--- a/bin/malt.rb
+++ b/bin/malt.rb
@@ -110,7 +110,7 @@ begin
   when "create"
     Malt::Project.create(options)
   when "start"
-    Malt::ServiceManager.start(options)
+    exit 1 unless Malt::ServiceManager.start(options)
   when "stop"
     Malt::ServiceManager.stop(options)
   when "status"

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -75,11 +75,6 @@ module Malt
         raise "Missing project_name in config"
       end
 
-      # Verify port settings
-      unless has_service?("php")
-        raise "Missing PHP ports in config"
-      end
-
       true
     end
 

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -220,6 +220,8 @@ module Malt
     end
 
     def self.generate_php_configs(config)
+      return unless config.has_service?("php")
+
       template_dir_path = MALT_TEMPLATES_PATH
       puts "Using templates from: #{template_dir_path}" if ENV["MALT_DEBUG"]
 
@@ -256,7 +258,7 @@ module Malt
                                             PORT: port,
                                             MALT_DIR: "{{MALT_DIR}}",
                                             HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
-                                            PHP_PORT: config.ports["php"].first
+                                            PHP_PORT: config.ports["php"]&.first
                                           })
           File.write(File.join(config.malt_dir, "conf", "nginx_#{port}.conf"), content)
         end

--- a/lib/project.rb
+++ b/lib/project.rb
@@ -248,18 +248,18 @@ module Malt
     end
 
     def self.generate_webserver_configs(config)
+      has_php = config.has_service?("php")
+
       if config.ports["nginx"]
-        nginx_template = Malt::Template.new(File.join(templates_dir, "nginx", "nginx.conf.erb"))
+        nginx_template_name = has_php ? "nginx.conf.erb" : "nginx-static.conf.erb"
+        nginx_template = Malt::Template.new(File.join(templates_dir, "nginx", nginx_template_name))
         nginx_main_template = Malt::Template.new(File.join(templates_dir, "nginx", "nginx_main.conf.erb"))
 
         nginx_includes = config.ports["nginx"].map { |port| "include {{MALT_DIR}}/conf/nginx_#{port}.conf.tmp;" }.join("\n  ")
         config.ports["nginx"].each do |port|
-          content = nginx_template.render({
-                                            PORT: port,
-                                            MALT_DIR: "{{MALT_DIR}}",
-                                            HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
-                                            PHP_PORT: config.ports["php"]&.first
-                                          })
+          vars = { PORT: port, MALT_DIR: "{{MALT_DIR}}", HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}" }
+          vars[:PHP_PORT] = config.ports["php"].first if has_php
+          content = nginx_template.render(vars)
           File.write(File.join(config.malt_dir, "conf", "nginx_#{port}.conf"), content)
         end
 
@@ -268,16 +268,13 @@ module Malt
       end
 
       if config.ports["httpd"]
-        httpd_template = Malt::Template.new(File.join(templates_dir, "httpd", "httpd.conf.erb"))
-        php_lib_path = "{{HOMEBREW_PREFIX}}/opt/php@#{config.php_version}/lib/httpd/modules/libphp.so"
+        httpd_template_name = has_php ? "httpd.conf.erb" : "httpd-static.conf.erb"
+        httpd_template = Malt::Template.new(File.join(templates_dir, "httpd", httpd_template_name))
 
         config.ports["httpd"].each do |port|
-          content = httpd_template.render({
-                                            PORT: port,
-                                            MALT_DIR: "{{MALT_DIR}}",
-                                            HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}",
-                                            PHP_LIB_PATH: php_lib_path
-                                          })
+          vars = { PORT: port, MALT_DIR: "{{MALT_DIR}}", HOMEBREW_PREFIX: "{{HOMEBREW_PREFIX}}" }
+          vars[:PHP_LIB_PATH] = "{{HOMEBREW_PREFIX}}/opt/php@#{config.php_version}/lib/httpd/modules/libphp.so" if has_php
+          content = httpd_template.render(vars)
           File.write(File.join(config.malt_dir, "conf", "httpd_#{port}.conf"), content)
         end
       end

--- a/lib/service_manager.rb
+++ b/lib/service_manager.rb
@@ -226,8 +226,14 @@ module Malt
           return false
         end
 
+        descendants = helper.descendant_pids(pid)
+
         puts "Forcibly terminating #{name} (pid #{pid})..."
-        Process.kill("KILL", pid)
+        [pid, *descendants].each do |target_pid|
+          Process.kill("KILL", target_pid)
+        rescue Errno::ESRCH
+          next
+        end
         helper.wait_for_pid_stop(pid, timeout: 5)
 
         if helper.pid_running?(pid)

--- a/lib/service_manager.rb
+++ b/lib/service_manager.rb
@@ -18,7 +18,6 @@ module Malt
       ensure_malt_dir_exists(config)
       start_services(config)
     end
-
     def self.stop(options)
       config_path = find_config_in_current_dir(options)
       config = Malt::Config.new(config_path)
@@ -66,9 +65,13 @@ module Malt
         services = register_services(config)
 
         # Start each service
-        services.each do |service|
-          service.start(config)
+        failed = services.reject { |service| service.start(config) }
+
+        unless failed.empty?
+          warn "Error: Failed to start: #{failed.map { |s| service_display_name(s) }.join(', ')}"
+          return false
         end
+
         puts "Services started."
         puts "Run 'source <(malt env)' to set up your shell environment."
 
@@ -76,18 +79,26 @@ module Malt
         display_web_server_urls(config)
 
         puts "See https://koriym.github.io/homebrew-malt/"
+        true
+      end
+
+      def service_display_name(service)
+        key = SERVICE_CLASSES.key(service.class)
+        key ? SERVICES[key][0] : service.class.name
       end
 
       def display_web_server_urls(config)
         web_servers = []
         if config.has_service?("httpd")
+          service = HttpdService.new
           config.ports["httpd"].each do |port|
-            web_servers << "http://127.0.0.1:#{port}/" if port_in_use?(port)
+            web_servers << "http://127.0.0.1:#{port}/" if service.running?(config, port)
           end
         end
         if config.has_service?("nginx")
+          service = NginxService.new
           config.ports["nginx"].each do |port|
-            web_servers << "http://127.0.0.1:#{port}/" if port_in_use?(port)
+            web_servers << "http://127.0.0.1:#{port}/" if service.running?(config, port)
           end
         end
 
@@ -125,57 +136,113 @@ module Malt
         "httpd" => ["Apache HTTPD", "httpd"],
       }.freeze
 
+      # config_key => service class, in startup order
+      SERVICE_CLASSES = {
+        "php" => PhpService,
+        "mysql" => MysqlService,
+        "redis" => RedisService,
+        "memcached" => MemcachedService,
+        "nginx" => NginxService,
+        "httpd" => HttpdService,
+      }.freeze
+
       def show_status(config)
         puts "Service status for #{config.project_name}:"
         puts ""
 
-        SERVICES.each do |key, (name, _)|
+        SERVICE_CLASSES.each do |key, klass|
           next unless config.has_service?(key)
 
-          config.ports[key].each do |port|
-            status = port_in_use?(port) ? "running" : "stopped"
+          name = SERVICES[key][0]
+          service = klass.new
+          config.ports[key].each_with_index do |port, index|
+            status =
+              if service.running?(config, port, index)
+                "running"
+              elsif port_in_use?(port)
+                "external process on port"
+              else
+                "stopped"
+              end
             puts "  #{name} (port #{port}): #{status}"
           end
         end
       end
 
+      # Forcibly terminate only processes recorded in the Malt pid registry.
+      # Each pid's identity is verified against the pattern stored at start
+      # time before sending SIGKILL, so foreign processes (e.g. Homebrew
+      # services) are never touched. Stale entries are pruned.
       def kill_services
-        running = SERVICES.values.select { |_, pattern| process_running?(pattern) }
+        helper = Malt::BaseService.new
+        entries = Malt::BaseService.registry_entries
+
+        # Keep only entries whose process is still running; prune the rest
+        running = entries.select { |entry| registry_entry_alive?(entry, helper) }
+
+        # Kill supervisors (entries with a direct pid, e.g. mysqld_safe)
+        # before the processes they supervise so they cannot restart them
+        running.sort_by! { |entry| entry["pid"] ? 0 : 1 }
 
         if running.empty?
           puts "No running instances of supported services were found."
           return
         end
 
-        puts "About to forcibly terminate the following running services:"
-        running.each { |name, _| puts "- #{name}" }
-        puts "(This command affects all instances, regardless of malt.json configuration)"
+        puts "About to forcibly terminate the following malt-managed services:"
+        running.each do |entry|
+          puts "- #{registry_entry_name(entry)} (pid #{registry_entry_pid(entry, helper)})"
+        end
+        puts "(Only processes started by malt are terminated; other instances are left untouched)"
 
-        any_killed = running.map { |name, pattern| kill_service(pattern, name) }.any?
+        any_killed = running.map { |entry| kill_registry_entry(entry, helper) }.any?
         puts "Forcible termination of services completed." if any_killed
       end
 
-      def process_running?(pattern)
-        system("pgrep", "-f", pattern, out: File::NULL, err: File::NULL)
+      def registry_entry_alive?(entry, helper)
+        pid = registry_entry_pid(entry, helper)
+        alive = pid && helper.pid_running?(pid)
+        FileUtils.rm_f(entry["_path"]) unless alive
+        !!alive
       end
 
-      def kill_service(pattern, name)
-        return false unless process_running?(pattern)
+      def registry_entry_pid(entry, helper)
+        return entry["pid"] if entry["pid"]
 
-        puts "Forcibly terminating #{name}..."
-        system("pkill", "-9", "-f", pattern)
-        sleep 0.5
+        helper.read_pid_file(entry["pid_file"])
+      end
 
-        # Retry if still running
-        if process_running?(pattern)
-          warn "Warning: #{name} processes still running despite SIGKILL, retrying..."
-          system("pkill", "-9", "-f", pattern)
-          sleep 0.5
+      def registry_entry_name(entry)
+        SERVICES.dig(entry["service"], 0) || entry["service"].to_s
+      end
+
+      def kill_registry_entry(entry, helper)
+        name = registry_entry_name(entry)
+        pid = registry_entry_pid(entry, helper)
+
+        unless pid && helper.pid_matches?(pid, entry["pattern"])
+          warn "Warning: #{name} pid #{pid || 'unknown'} does not match the expected process. Leaving it untouched."
+          FileUtils.rm_f(entry["_path"])
+          return false
         end
 
-        still_running = process_running?(pattern)
-        warn "Warning: Failed to forcibly terminate #{name}" if still_running
-        !still_running
+        puts "Forcibly terminating #{name} (pid #{pid})..."
+        Process.kill("KILL", pid)
+        helper.wait_for_pid_stop(pid, timeout: 5)
+
+        if helper.pid_running?(pid)
+          warn "Warning: Failed to forcibly terminate #{name}"
+          return false
+        end
+
+        FileUtils.rm_f(entry["_path"])
+        true
+      rescue Errno::ESRCH
+        FileUtils.rm_f(entry["_path"])
+        true
+      rescue Errno::EPERM => e
+        warn "Warning: Failed to terminate #{name}: #{e.message}"
+        false
       end
 
       # Clean up old temporary config files to prevent .tmp.tmp accumulation
@@ -196,27 +263,7 @@ module Malt
       end
 
       def register_services(config)
-        services = []
-
-        # PHP-FPM
-        services << PhpService.new if config.has_service?("php")
-
-        # MySQL
-        services << MysqlService.new if config.has_service?("mysql")
-
-        # Redis
-        services << RedisService.new if config.has_service?("redis")
-
-        # Memcached
-        services << MemcachedService.new if config.has_service?("memcached")
-
-        # Nginx
-        services << NginxService.new if config.has_service?("nginx")
-
-        # Apache
-        services << HttpdService.new if config.has_service?("httpd")
-
-        services
+        SERVICE_CLASSES.filter_map { |key, klass| klass.new if config.has_service?(key) }
       end
     end
   end

--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -168,6 +168,16 @@ module Malt
       nil
     end
 
+    # Direct and indirect children of pid (e.g. php-fpm/nginx workers forked
+    # from a supervisor). SIGKILL isn't forwarded by the OS, so callers that
+    # forcibly kill a supervisor must also kill its descendants explicitly.
+    def descendant_pids(pid)
+      direct = IO.popen(["pgrep", "-P", pid.to_s], &:read).to_s.split("\n").filter_map { |p| Integer(p, exception: false) }
+      direct + direct.flat_map { |child_pid| descendant_pids(child_pid) }
+    rescue SystemCallError
+      []
+    end
+
     def terminate_pid(pid, label, timeout: 1)
       return unless pid && pid_running?(pid)
 

--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -24,7 +24,17 @@ module Malt
       return [] unless Dir.exist?(dir)
 
       Dir.glob(File.join(dir, "*.json")).filter_map do |path|
-        JSON.parse(File.read(path)).merge("_path" => path)
+        entry = JSON.parse(File.read(path))
+        next unless entry.is_a?(Hash)
+
+        pattern = Array(entry["pattern"])
+        next if pattern.empty? || pattern.any? { |p| !p.is_a?(String) || p.empty? }
+
+        valid_pid = entry["pid"].is_a?(Integer) && entry["pid"].positive?
+        valid_pid_file = entry["pid_file"].is_a?(String) && !entry["pid_file"].empty?
+        next unless valid_pid || valid_pid_file
+
+        entry.merge("_path" => path)
       rescue JSON::ParserError, SystemCallError
         nil
       end

--- a/lib/services/base_service.rb
+++ b/lib/services/base_service.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "fileutils"
+require "json"
+require "digest"
 
 module Malt
   # Homebrew prefix constant shared across services
@@ -8,6 +10,45 @@ module Malt
 
   # Base service class providing common functionality for all services
   class BaseService
+    # Global registry of malt-started service processes, shared across all
+    # malt projects. `malt kill` only terminates processes recorded here,
+    # after verifying each pid's identity against the stored pattern.
+    def self.registry_dir
+      ENV["MALT_REGISTRY_DIR"] || File.join(HOMEBREW_PREFIX, "var", "malt", "pids")
+    end
+
+    # Read all registry entries. Each entry is a Hash with "service",
+    # "pattern", plus "pid" and/or "pid_file", and "_path" for its file.
+    def self.registry_entries
+      dir = registry_dir
+      return [] unless Dir.exist?(dir)
+
+      Dir.glob(File.join(dir, "*.json")).filter_map do |path|
+        JSON.parse(File.read(path)).merge("_path" => path)
+      rescue JSON::ParserError, SystemCallError
+        nil
+      end
+    end
+
+    # Record a malt-started process in the registry. `key` must be a stable
+    # identifier (e.g. the pid file path) so the entry can be removed on stop.
+    # Pass pid: for a known pid, pid_file: when the pid is read from a file.
+    def register_process(service, key, expected_pattern, pid: nil, pid_file: nil)
+      FileUtils.mkdir_p(self.class.registry_dir)
+      entry = { "service" => service, "pattern" => Array(expected_pattern).map(&:to_s) }
+      entry["pid"] = pid if pid
+      entry["pid_file"] = pid_file if pid_file
+      File.write(registry_entry_path(key), JSON.generate(entry))
+    end
+
+    def unregister_process(key)
+      FileUtils.rm_f(registry_entry_path(key))
+    end
+
+    def registry_entry_path(key)
+      File.join(self.class.registry_dir, "#{Digest::MD5.hexdigest(key)}.json")
+    end
+
     # Create temporary config file with variable expansion
     def create_temp_config(config, config_path)
       create_temp_config_with_extras(config, config_path, {})

--- a/lib/services/httpd_service.rb
+++ b/lib/services/httpd_service.rb
@@ -6,9 +6,13 @@ module Malt
   # Apache HTTPD service class
   class HttpdService < BaseService
     def start(config)
-      config.ports["httpd"].each do |port|
-        start_httpd(config, port)
-      end
+      results = config.ports["httpd"].map { |port| start_httpd(config, port) }
+      results.all?
+    end
+
+    # Check whether Apache HTTPD on the given port is running under Malt management
+    def running?(config, port, _index = nil)
+      pid_running_from_file?(httpd_pid_file(config, port), expected_pattern: httpd_temp_config_path(config, port))
     end
 
     def stop(config)
@@ -21,10 +25,12 @@ module Malt
 
     def start_httpd(config, port)
       FileUtils.mkdir_p(config.var_dir)
+      FileUtils.mkdir_p(config.logs_dir)
       pid_file = httpd_pid_file(config, port)
       if pid_running_from_file?(pid_file, expected_pattern: httpd_temp_config_path(config, port))
         puts "[Running] Apache HTTPD on port #{port}"
-        return
+        register_process("httpd", pid_file, httpd_temp_config_path(config, port), pid_file: pid_file)
+        return true
       elsif File.exist?(pid_file)
         remove_stale_pid_file(pid_file)
       end
@@ -32,7 +38,7 @@ module Malt
       # Check if port is already in use
       if port_in_use?(port)
         puts "Error: Port #{port} is already in use by another process"
-        return
+        return false
       end
 
       puts "Starting Apache HTTPD on port #{port}..."
@@ -45,27 +51,30 @@ module Malt
       # Abort if temp config creation failed
       if temp_conf.nil?
         puts "Error: Failed to create temporary config file for Apache HTTPD on port #{port}"
-        return
+        return false
       end
 
       # Verify temp file exists
       unless File.exist?(temp_conf)
         puts "Error: Apache HTTPD config temp file not found at: #{temp_conf}"
-        return
+        return false
       end
 
-      # Start with temporary config
+      # Start with temporary config (redirect output so the daemon doesn't hold the caller's pipes open)
       httpd = File.join(HOMEBREW_PREFIX, "bin", "httpd")
+      log_file = File.join(config.logs_dir, "httpd_#{port}.log")
       puts "Running command: #{httpd} -f #{temp_conf}"
       begin
-        pid = Process.spawn(httpd, "-f", temp_conf)
+        pid = Process.spawn(httpd, "-f", temp_conf, out: [log_file, "a"], err: [:child, :out])
         Process.detach(pid)
       rescue SystemCallError => e
         puts "Error: Failed to start Apache HTTPD on port #{port}"
         puts e.message if ENV["MALT_DEBUG"]
-        return
+        return false
       end
+      register_process("httpd", pid_file, httpd_temp_config_path(config, port), pid_file: pid_file)
       puts "Apache HTTPD starting in background..."
+      true
     end
 
     def stop_httpd(config, port)
@@ -77,6 +86,7 @@ module Malt
           puts "[Stopped] Apache HTTPD is not running on port #{port}"
         end
         cleanup_httpd_temp(config, port)
+        unregister_process(pid_file)
         return false
       end
 
@@ -85,6 +95,7 @@ module Malt
         puts "[Stopped] Apache HTTPD is not running on port #{port}"
         remove_stale_pid_file(pid_file)
         cleanup_httpd_temp(config, port)
+        unregister_process(pid_file)
         return false
       end
 
@@ -111,6 +122,7 @@ module Malt
 
       remove_stale_pid_file(pid_file) if stopped
       cleanup_httpd_temp(config, port) if stopped || !File.exist?(pid_file)
+      unregister_process(pid_file) if stopped
       stopped
     end
 

--- a/lib/services/memcached_service.rb
+++ b/lib/services/memcached_service.rb
@@ -6,9 +6,14 @@ module Malt
   # Memcached service class
   class MemcachedService < BaseService
     def start(config)
-      config.ports["memcached"].each do |port|
-        start_memcached(config, port)
-      end
+      results = config.ports["memcached"].map { |port| start_memcached(config, port) }
+      results.all?
+    end
+
+    # Check whether Memcached on the given port is running under Malt management
+    def running?(config, port, _index = nil)
+      pid_file = File.join(config.var_dir, "memcached_#{port}.pid")
+      pid_running_from_file?(pid_file, expected_pattern: memcached_identity_pattern)
     end
 
     def stop(config)
@@ -24,7 +29,8 @@ module Malt
       pid_file = File.join(config.var_dir, "memcached_#{port}.pid")
       if pid_running_from_file?(pid_file, expected_pattern: memcached_identity_pattern)
         puts "[Running] Memcached on port #{port}"
-        return
+        register_process("memcached", pid_file, memcached_identity_pattern, pid_file: pid_file)
+        return true
       elsif File.exist?(pid_file)
         remove_stale_pid_file(pid_file)
       end
@@ -32,7 +38,7 @@ module Malt
       # Check if port is already in use
       if port_in_use?(port)
         puts "Error: Port #{port} is already in use by another process"
-        return
+        return false
       end
 
       puts "Starting Memcached on port #{port}..."
@@ -44,10 +50,14 @@ module Malt
         sleep 0.1
       end
 
-      return if started && pid_running_from_file?(pid_file, expected_pattern: memcached_identity_pattern)
+      if started && pid_running_from_file?(pid_file, expected_pattern: memcached_identity_pattern)
+        register_process("memcached", pid_file, memcached_identity_pattern, pid_file: pid_file)
+        return true
+      end
 
       warn "Error: Failed to start Memcached on port #{port}"
       remove_stale_pid_file(pid_file)
+      false
     end
 
     def stop_memcached(config, port)
@@ -58,10 +68,13 @@ module Malt
         else
           puts "[Stopped] Memcached is not running on port #{port}"
         end
+        unregister_process(pid_file)
         return false
       end
 
-      stop_pid_file(pid_file, "Memcached on port #{port}", expected_pattern: memcached_identity_pattern)
+      stopped = stop_pid_file(pid_file, "Memcached on port #{port}", expected_pattern: memcached_identity_pattern)
+      unregister_process(pid_file) if stopped
+      stopped
     end
 
     def memcached_identity_pattern

--- a/lib/services/mysql_service.rb
+++ b/lib/services/mysql_service.rb
@@ -6,9 +6,14 @@ module Malt
   # MySQL service class
   class MysqlService < BaseService
     def start(config)
-      config.ports["mysql"].each_with_index do |port, index|
-        start_mysql(config, port, index)
-      end
+      results = config.ports["mysql"].each_with_index.map { |port, index| start_mysql(config, port, index) }
+      results.all?
+    end
+
+    # Check whether the given MySQL instance is running under Malt management
+    def running?(config, _port, index = nil)
+      pid_file = mysql_pid_file(config, index)
+      pid_running_from_file?(pid_file, expected_pattern: mysql_identity_pattern(config, index))
     end
 
     def stop(config)
@@ -31,7 +36,8 @@ module Malt
       pid_file = mysql_pid_file(config, index)
       if pid_running_from_file?(pid_file, expected_pattern: mysql_identity_pattern(config, index))
         puts "[Running] MySQL on port #{port}"
-        return
+        register_mysql_process(config, index)
+        return true
       elsif File.exist?(pid_file)
         remove_stale_pid_file(pid_file)
       end
@@ -39,7 +45,7 @@ module Malt
       # Check if port is already in use
       if port_in_use?(port)
         puts "Error: Port #{port} is already in use by another process"
-        return
+        return false
       end
 
       puts "Starting MySQL on port #{port}..."
@@ -52,7 +58,7 @@ module Malt
       # Abort if temp config creation failed
       if temp_conf.nil?
         puts "Error: Failed to create temporary config file for MySQL on port #{port}"
-        return
+        return false
       end
 
       puts "MySQL config path: #{temp_conf}"
@@ -74,7 +80,7 @@ module Malt
         mysqld = File.join(HOMEBREW_PREFIX, "opt", "mysql@#{config.mysql_version}", "bin", "mysqld")
         unless system(mysqld, "--initialize-insecure", "--datadir=#{data_dir}")
           puts "Error: MySQL initialization failed"
-          return
+          return false
         end
         puts "MySQL initialization complete."
       end
@@ -82,16 +88,32 @@ module Malt
       # Verify temp file exists
       unless File.exist?(temp_conf)
         puts "Error: MySQL config temp file not found at: #{temp_conf}"
-        return
+        return false
       end
 
       # Start MySQL in background
       mysqld_safe = File.join(HOMEBREW_PREFIX, "opt", "mysql@#{config.mysql_version}", "bin", "mysqld_safe")
       pid = Process.spawn(mysqld_safe, "--defaults-file=#{temp_conf}", out: [log_file, "a"], err: [:child, :out])
       Process.detach(pid)
+      # Register mysqld_safe (supervisor) by pid and mysqld by its pid file
+      register_process("mysql", "#{pid_file}.safe", ["mysqld_safe", temp_conf], pid: pid)
+      register_mysql_process(config, index)
       puts "MySQL starting in background..."
+      true
     rescue SystemCallError => e
       puts "Error: Failed to start MySQL on port #{port}: #{e.message}"
+      false
+    end
+
+    def register_mysql_process(config, index)
+      pid_file = mysql_pid_file(config, index)
+      register_process("mysql", pid_file, mysql_identity_pattern(config, index), pid_file: pid_file)
+    end
+
+    def unregister_mysql_process(config, index)
+      pid_file = mysql_pid_file(config, index)
+      unregister_process(pid_file)
+      unregister_process("#{pid_file}.safe")
     end
 
     def stop_mysql(config, port, index)
@@ -103,6 +125,7 @@ module Malt
           puts "[Stopped] MySQL is not running on port #{port}"
         end
         cleanup_mysql_temp(config, port)
+        unregister_mysql_process(config, index)
         return false
       end
 
@@ -111,6 +134,7 @@ module Malt
         puts "[Stopped] MySQL is not running on port #{port}"
         remove_stale_pid_file(pid_file)
         cleanup_mysql_temp(config, port)
+        unregister_mysql_process(config, index)
         return false
       end
 
@@ -135,6 +159,7 @@ module Malt
 
       remove_stale_pid_file(pid_file) if stopped
       cleanup_mysql_temp(config, port) if stopped || !File.exist?(pid_file)
+      unregister_mysql_process(config, index) if stopped
       stopped
     end
 

--- a/lib/services/nginx_service.rb
+++ b/lib/services/nginx_service.rb
@@ -9,6 +9,11 @@ module Malt
       start_nginx(config)
     end
 
+    # Check whether Nginx is running under Malt management
+    def running?(config, _port = nil, _index = nil)
+      pid_running_from_file?(nginx_pid_file(config), expected_pattern: nginx_temp_config(config))
+    end
+
     def stop(config)
       stop_nginx(config)
     end
@@ -22,7 +27,8 @@ module Malt
 
       if pid_running_from_file?(pid_file, expected_pattern: nginx_temp_config(config))
         puts "[Running] Nginx on ports #{ports_str}"
-        return
+        register_process("nginx", pid_file, nginx_temp_config(config), pid_file: pid_file)
+        return true
       elsif File.exist?(pid_file)
         remove_stale_pid_file(pid_file)
       end
@@ -30,7 +36,7 @@ module Malt
       conflict_ports = config.ports["nginx"].select { |port| port_in_use?(port) }
       unless conflict_ports.empty?
         puts "Error: Nginx port(s) already in use by another process: #{conflict_ports.join(', ')}"
-        return
+        return false
       end
 
       puts "Starting Nginx on ports #{ports_str}..."
@@ -39,13 +45,18 @@ module Malt
       # Error if temp file creation failed
       if temp_conf.nil?
         puts "Error: Failed to create temporary config file for Nginx"
-        return
+        return false
       end
 
       # Start nginx with temporary config
       nginx_bin = File.join(HOMEBREW_PREFIX, "bin", "nginx")
       puts "Running command: #{nginx_bin} -c #{temp_conf}"
-      puts "Error: Failed to start Nginx" unless system(nginx_bin, "-c", temp_conf)
+      unless system(nginx_bin, "-c", temp_conf)
+        puts "Error: Failed to start Nginx"
+        return false
+      end
+      register_process("nginx", pid_file, nginx_temp_config(config), pid_file: pid_file)
+      true
     end
 
     def stop_nginx(config)
@@ -58,11 +69,13 @@ module Malt
         else
           warn "Warning: Nginx appears to be running on port(s) #{running_ports.join(', ')}, but no Malt pid file was found. Leaving it untouched."
         end
+        unregister_process(pid_file)
         return false
       end
 
       stopped = stop_nginx_with_config(config, pid_file)
       cleanup_nginx_temp_files(config) if stopped || !File.exist?(pid_file)
+      unregister_process(pid_file) if stopped
       stopped
     end
 

--- a/lib/services/php_service.rb
+++ b/lib/services/php_service.rb
@@ -6,9 +6,14 @@ module Malt
   # PHP-FPM service class
   class PhpService < BaseService
     def start(config)
-      config.ports["php"].each do |port|
-        start_php_fpm(config, port)
-      end
+      results = config.ports["php"].map { |port| start_php_fpm(config, port) }
+      results.all?
+    end
+
+    # Check whether PHP-FPM on the given port is running under Malt management
+    def running?(config, port, _index = nil)
+      pid_file = File.join(config.var_dir, "php-fpm_#{port}.pid")
+      pid_running_from_file?(pid_file, expected_pattern: php_fpm_temp_conf(config, port))
     end
 
     def stop(config)
@@ -24,7 +29,8 @@ module Malt
       pid_file = File.join(config.var_dir, "php-fpm_#{port}.pid")
       if pid_running_from_file?(pid_file, expected_pattern: php_fpm_temp_conf(config, port))
         puts "[Running] PHP-FPM on port #{port}"
-        return
+        register_process("php", pid_file, php_fpm_temp_conf(config, port), pid_file: pid_file)
+        return true
       elsif File.exist?(pid_file)
         remove_stale_pid_file(pid_file)
       end
@@ -32,11 +38,12 @@ module Malt
       # Check if port is already in use
       if port_in_use?(port)
         puts "Error: Port #{port} is already in use by another process"
-        return
+        return false
       end
 
       puts "Starting PHP-FPM on port #{port}..."
       FileUtils.mkdir_p(config.var_dir)
+      FileUtils.mkdir_p(config.logs_dir)
 
       # Configuration file paths
       php_fpm_conf = File.join(config.conf_dir, "php-fpm_#{port}.conf")
@@ -45,7 +52,7 @@ module Malt
       # Verify config file exists
       unless File.exist?(php_fpm_conf)
         puts "PHP-FPM configuration file not found at: #{php_fpm_conf}"
-        return
+        return false
       end
 
       # Create temporary config files with variable expansion
@@ -55,26 +62,30 @@ module Malt
       # Error if temporary file creation failed
       if temp_conf.nil?
         puts "Error: Failed to create temporary config file for PHP-FPM"
-        return
+        return false
       end
 
       if temp_ini.nil?
         puts "Error: Failed to create temporary config file for PHP.ini"
-        return
+        return false
       end
 
       puts "Using PHP-FPM config file: #{temp_conf}"
       puts "Using PHP.ini file: #{temp_ini}"
 
-      # Start using temporary files
+      # Start using temporary files (redirect output so daemons don't hold the caller's pipes open)
       php_fpm_bin = File.join(HOMEBREW_PREFIX, "opt", "php@#{config.php_version}", "sbin", "php-fpm")
+      log_file = File.join(config.logs_dir, "php-fpm_#{port}.log")
       pid = nil
-      pid = Process.spawn(php_fpm_bin, "-y", temp_conf, "-c", temp_ini)
+      pid = Process.spawn(php_fpm_bin, "-y", temp_conf, "-c", temp_ini, out: [log_file, "a"], err: [:child, :out])
       File.write(pid_file, pid.to_s)
       Process.detach(pid)
+      register_process("php", pid_file, php_fpm_temp_conf(config, port), pid_file: pid_file)
+      true
     rescue SystemCallError, StandardError => e
       terminate_pid(pid, "PHP-FPM on port #{port}") if pid
       puts "Error: Failed to start PHP-FPM on port #{port}: #{e.message}"
+      false
     end
 
     def stop_php_fpm(config, port)
@@ -86,11 +97,13 @@ module Malt
           puts "[Stopped] PHP-FPM is not running on port #{port}"
         end
         cleanup_php_fpm_temp(config, port)
+        unregister_process(pid_file)
         return false
       end
 
       stopped = stop_pid_file(pid_file, "PHP-FPM on port #{port}", expected_pattern: php_fpm_temp_conf(config, port))
       cleanup_php_fpm_temp(config, port) if stopped || !File.exist?(pid_file)
+      unregister_process(pid_file) if stopped
       stopped
     end
 

--- a/lib/services/redis_service.rb
+++ b/lib/services/redis_service.rb
@@ -6,9 +6,13 @@ module Malt
   # Redis service class
   class RedisService < BaseService
     def start(config)
-      config.ports["redis"].each do |port|
-        start_redis(config, port)
-      end
+      results = config.ports["redis"].map { |port| start_redis(config, port) }
+      results.all?
+    end
+
+    # Check whether Redis on the given port is running under Malt management
+    def running?(config, port, _index = nil)
+      pid_running_from_file?(redis_pid_file(config, port), expected_pattern: redis_identity_pattern(port))
     end
 
     def stop(config)
@@ -24,7 +28,8 @@ module Malt
       pid_file = redis_pid_file(config, port)
       if pid_running_from_file?(pid_file, expected_pattern: redis_identity_pattern(port))
         puts "[Running] Redis on port #{port}"
-        return
+        register_process("redis", pid_file, redis_identity_pattern(port), pid_file: pid_file)
+        return true
       elsif File.exist?(pid_file)
         remove_stale_pid_file(pid_file)
       end
@@ -32,7 +37,7 @@ module Malt
       # Check if port is already in use
       if port_in_use?(port)
         puts "Error: Port #{port} is already in use by another process"
-        return
+        return false
       end
 
       puts "Starting Redis on port #{port}..."
@@ -42,14 +47,14 @@ module Malt
       # Verify config file exists
       unless File.exist?(redis_conf)
         puts "Redis configuration file not found at: #{redis_conf}"
-        return
+        return false
       end
 
       # Ensure tmp directory exists for Redis
       FileUtils.mkdir_p(File.join(config.malt_dir, "tmp"))
 
       # Ensure logs directory exists
-      FileUtils.mkdir_p(File.join(config.malt_dir, "logs"))
+      FileUtils.mkdir_p(config.logs_dir)
 
       # Create temporary config file with variable expansion
       temp_conf = create_temp_config(config, redis_conf)
@@ -57,21 +62,26 @@ module Malt
       # Abort if temp config creation failed
       if temp_conf.nil?
         puts "Error: Failed to create temporary config file for Redis on port #{port}"
-        return
+        return false
       end
 
-      # Start Redis with temporary config
+      # Start Redis with temporary config (redirect output so the daemon doesn't hold the caller's pipes open)
       puts "Running command: redis-server #{temp_conf}"
+      log_file = File.join(config.logs_dir, "redis_#{port}.log")
       pid = nil
-      pid = Process.spawn("redis-server", temp_conf)
+      pid = Process.spawn("redis-server", temp_conf, out: [log_file, "a"], err: [:child, :out])
       File.write(pid_file, pid.to_s)
       Process.detach(pid)
+      register_process("redis", pid_file, redis_identity_pattern(port), pid_file: pid_file)
+      true
     rescue SystemCallError => e
       terminate_pid(pid, "Redis on port #{port}") if pid
       puts "Error: Failed to start Redis on port #{port}: #{e.message}"
+      false
     rescue StandardError => e
       terminate_pid(pid, "Redis on port #{port}") if pid
       puts "Error: Failed to persist Redis pid file for port #{port}: #{e.message}"
+      false
     end
 
     def stop_redis(config, port)
@@ -84,11 +94,13 @@ module Malt
           puts "[Stopped] Redis is not running on port #{port}"
         end
         cleanup_redis_temp(config, port)
+        unregister_process(pid_file)
         return false
       end
 
       stopped = stop_pid_file(pid_file, "Redis on port #{port}", expected_pattern: redis_identity_pattern(port))
       cleanup_redis_temp(config, port) if stopped || !File.exist?(pid_file)
+      unregister_process(pid_file) if stopped
       stopped
     end
 

--- a/share/templates/httpd/httpd-static.conf.erb
+++ b/share/templates/httpd/httpd-static.conf.erb
@@ -1,0 +1,23 @@
+Listen {{PORT}}
+PidFile "{{MALT_DIR}}/var/httpd_{{PORT}}.pid"
+DocumentRoot "{{PROJECT_DIR}}/public"
+<Directory "{{PROJECT_DIR}}/public">
+  Options Indexes FollowSymLinks
+  AllowOverride All
+  Require all granted
+</Directory>
+
+ErrorLog "{{MALT_DIR}}/logs/httpd_{{PORT}}_error.log"
+
+LoadModule unixd_module "{{HOMEBREW_PREFIX}}/opt/httpd/lib/httpd/modules/mod_unixd.so"
+LoadModule mpm_prefork_module "{{HOMEBREW_PREFIX}}/opt/httpd/lib/httpd/modules/mod_mpm_prefork.so"
+LoadModule authz_core_module "{{HOMEBREW_PREFIX}}/opt/httpd/lib/httpd/modules/mod_authz_core.so"
+LoadModule authz_host_module "{{HOMEBREW_PREFIX}}/opt/httpd/lib/httpd/modules/mod_authz_host.so"
+LoadModule dir_module "{{HOMEBREW_PREFIX}}/opt/httpd/lib/httpd/modules/mod_dir.so"
+
+ServerName localhost
+ServerRoot "{{HOMEBREW_PREFIX}}/opt/httpd"
+
+<IfModule dir_module>
+    DirectoryIndex index.html
+</IfModule>

--- a/share/templates/nginx/nginx-static.conf.erb
+++ b/share/templates/nginx/nginx-static.conf.erb
@@ -1,0 +1,13 @@
+server {
+  listen {{PORT}};
+  server_name localhost;
+  root "{{PROJECT_DIR}}/public";
+  index index.html index.htm;
+
+  access_log "{{MALT_DIR}}/logs/nginx_{{PORT}}_access.log";
+  error_log "{{MALT_DIR}}/logs/nginx_{{PORT}}_error.log";
+
+  location / {
+    try_files $uri $uri/ =404;
+  }
+}

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -206,16 +206,14 @@ class ConfigTest < Minitest::Test
     end
   end
 
-  def test_validate_raises_for_missing_php_ports
+  def test_validate_passes_without_php_ports
     write_config({
       "project_name" => "test",
-      "ports" => { "mysql" => [3306] }
+      "ports" => { "redis" => [6379] }
     })
 
     config = Malt::Config.new(@config_path)
 
-    assert_raises RuntimeError do
-      config.validate!
-    end
+    assert config.validate!
   end
 end

--- a/test/kill_registry_test.rb
+++ b/test/kill_registry_test.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "socket"
+
+class KillRegistryTest < Minitest::Test
+  def setup
+    @temp_dir = Dir.mktmpdir("malt_test")
+    @registry_dir = File.join(@temp_dir, "registry")
+    @saved_registry_dir = ENV["MALT_REGISTRY_DIR"]
+    ENV["MALT_REGISTRY_DIR"] = @registry_dir
+
+    File.write(File.join(@temp_dir, "malt.json"), <<~JSON)
+      {
+        "project_name": "test_project",
+        "dependencies": ["php@8.4", "redis"],
+        "ports": {
+          "php": [9000],
+          "redis": [6379]
+        },
+        "php_extensions": []
+      }
+    JSON
+    FileUtils.mkdir_p(File.join(@temp_dir, "malt", "conf"))
+    FileUtils.mkdir_p(File.join(@temp_dir, "malt", "logs"))
+    FileUtils.mkdir_p(File.join(@temp_dir, "malt", "var"))
+
+    @config = Malt::Config.new(File.join(@temp_dir, "malt.json"))
+    @service = Malt::BaseService.new
+  end
+
+  def teardown
+    ENV["MALT_REGISTRY_DIR"] = @saved_registry_dir
+    FileUtils.rm_rf(@temp_dir)
+  end
+
+  def test_register_and_unregister_process_roundtrip
+    key = File.join(@temp_dir, "malt", "var", "redis_6379.pid")
+    @service.register_process("redis", key, ["redis-server", "6379"], pid_file: key)
+
+    entries = Malt::BaseService.registry_entries
+    assert_equal 1, entries.size
+    assert_equal "redis", entries[0]["service"]
+    assert_equal ["redis-server", "6379"], entries[0]["pattern"]
+    assert_equal key, entries[0]["pid_file"]
+
+    @service.unregister_process(key)
+    assert_empty Malt::BaseService.registry_entries
+  end
+
+  def test_kill_terminates_registered_matching_process
+    pid = Process.spawn("sleep", "30")
+    Process.detach(pid)
+    key = File.join(@temp_dir, "sleep.pid")
+    @service.register_process("redis", key, ["sleep"], pid: pid)
+
+    out, = capture_io { Malt::ServiceManager.send(:kill_services) }
+
+    assert_includes out, "Forcibly terminating Redis (pid #{pid})"
+    refute @service.pid_running?(pid), "expected sleep process to be killed"
+    assert_empty Malt::BaseService.registry_entries
+  ensure
+    Process.kill("KILL", pid) rescue nil
+  end
+
+  def test_kill_leaves_process_alive_when_command_does_not_match
+    pid = Process.spawn("sleep", "30")
+    Process.detach(pid)
+    key = File.join(@temp_dir, "fake-mysql.pid")
+    @service.register_process("mysql", key, ["mysqld"], pid: pid)
+
+    _, err = capture_io { Malt::ServiceManager.send(:kill_services) }
+
+    assert @service.pid_running?(pid), "foreign process must not be killed"
+    assert_includes err, "does not match the expected process"
+    assert_empty Malt::BaseService.registry_entries
+  ensure
+    Process.kill("KILL", pid) rescue nil
+  end
+
+  def test_kill_prunes_stale_entries_and_reports_nothing_running
+    key = File.join(@temp_dir, "stale.pid")
+    @service.register_process("redis", key, ["sleep"], pid: 2_147_483_000)
+
+    out, = capture_io { Malt::ServiceManager.send(:kill_services) }
+
+    assert_includes out, "No running instances of supported services were found."
+    assert_empty Malt::BaseService.registry_entries
+  end
+
+  def test_status_reports_external_process_when_port_occupied_by_foreign_process
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    write_ports("redis" => [port])
+
+    config = Malt::Config.new(File.join(@temp_dir, "malt.json"))
+    out, = capture_io { Malt::ServiceManager.send(:show_status, config) }
+
+    assert_includes out, "Redis (port #{port}): external process on port"
+  ensure
+    server.close
+  end
+
+  def test_status_reports_stopped_when_port_free_and_no_pid_file
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    server.close
+    write_ports("redis" => [port])
+
+    config = Malt::Config.new(File.join(@temp_dir, "malt.json"))
+    out, = capture_io { Malt::ServiceManager.send(:show_status, config) }
+
+    assert_includes out, "Redis (port #{port}): stopped"
+  end
+
+  def test_status_reports_running_when_service_confirms_malt_process
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    write_ports("redis" => [port])
+
+    fake = Object.new
+    def fake.running?(_config, _port, _index = nil)
+      true
+    end
+
+    config = Malt::Config.new(File.join(@temp_dir, "malt.json"))
+    out, = Malt::RedisService.stub(:new, fake) do
+      capture_io { Malt::ServiceManager.send(:show_status, config) }.first
+    end
+
+    assert_includes out, "Redis (port #{port}): running"
+  ensure
+    server.close
+  end
+
+  def test_start_returns_false_and_reports_failure_when_port_in_use
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    write_ports("php" => [port])
+
+    _, err = capture_io do
+      result = Malt::ServiceManager.start(config: File.join(@temp_dir, "malt.json"))
+      assert_equal false, result
+    end
+
+    assert_includes err, "Failed to start: PHP-FPM"
+  ensure
+    server.close
+  end
+
+  def test_service_start_returns_false_when_port_in_use
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+
+    assert_equal false, Malt::PhpService.new.start(config_with_ports("php" => [port]))
+    assert_equal false, Malt::RedisService.new.start(config_with_ports("redis" => [port]))
+    assert_equal false, Malt::MemcachedService.new.start(config_with_ports("memcached" => [port]))
+  ensure
+    server.close
+  end
+
+  def test_display_web_server_urls_skips_external_process
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    write_ports("httpd" => [port])
+
+    config = Malt::Config.new(File.join(@temp_dir, "malt.json"))
+    out, = capture_io { Malt::ServiceManager.send(:display_web_server_urls, config) }
+
+    refute_includes out, "Access your site at"
+  ensure
+    server.close
+  end
+
+  private
+
+  def write_ports(ports)
+    File.write(File.join(@temp_dir, "malt.json"), JSON.generate({
+      "project_name" => "test_project",
+      "dependencies" => ["php@8.4"],
+      "ports" => ports,
+      "php_extensions" => []
+    }))
+  end
+
+  def config_with_ports(ports)
+    write_ports(ports)
+    Malt::Config.new(File.join(@temp_dir, "malt.json"))
+  end
+end

--- a/test/kill_registry_test.rb
+++ b/test/kill_registry_test.rb
@@ -78,6 +78,17 @@ class KillRegistryTest < Minitest::Test
     Process.kill("KILL", pid) rescue nil
   end
 
+  def test_registry_entries_ignores_entry_without_pattern
+    pid = Process.spawn("sleep", "30")
+    Process.detach(pid)
+    FileUtils.mkdir_p(@registry_dir)
+    File.write(File.join(@registry_dir, "malformed.json"), JSON.generate({ "service" => "redis", "pid" => pid }))
+
+    assert_empty Malt::BaseService.registry_entries
+  ensure
+    Process.kill("KILL", pid) rescue nil
+  end
+
   def test_kill_prunes_stale_entries_and_reports_nothing_running
     key = File.join(@temp_dir, "stale.pid")
     @service.register_process("redis", key, ["sleep"], pid: 2_147_483_000)

--- a/test/project_test.rb
+++ b/test/project_test.rb
@@ -41,6 +41,40 @@ class ProjectTest < Minitest::Test
     assert_includes stdout, "--defaults-file\\=#{File.join(@temp_dir, "malt", "conf", "my_3306.cnf")}"
   end
 
+  def test_create_generates_php_free_nginx_config_without_fastcgi
+    config_path = File.join(@temp_dir, "malt.json")
+    File.write(config_path, JSON.generate({
+      "project_name" => "static_site",
+      "dependencies" => [],
+      "ports" => { "nginx" => [8080] },
+      "php_extensions" => []
+    }))
+
+    _stdout, stderr, status = run_malt("create", "--config", config_path)
+
+    assert status.success?, stderr
+    content = File.read(File.join(@temp_dir, "malt", "conf", "nginx_8080.conf"))
+    refute_includes content, "fastcgi_pass"
+    refute_includes content, "index.php"
+  end
+
+  def test_create_generates_php_free_httpd_config_without_php_module
+    config_path = File.join(@temp_dir, "malt.json")
+    File.write(config_path, JSON.generate({
+      "project_name" => "static_site",
+      "dependencies" => [],
+      "ports" => { "httpd" => [8081] },
+      "php_extensions" => []
+    }))
+
+    _stdout, stderr, status = run_malt("create", "--config", config_path)
+
+    assert status.success?, stderr
+    content = File.read(File.join(@temp_dir, "malt", "conf", "httpd_8081.conf"))
+    refute_includes content, "php_module"
+    refute_includes content, "x-httpd-php"
+  end
+
   def test_install_deps_returns_nonzero_when_brew_install_fails
     write_fake_brew(fail_install: true)
     config_path = File.join(@temp_dir, "malt.json")

--- a/test/project_test.rb
+++ b/test/project_test.rb
@@ -110,8 +110,10 @@ class ProjectTest < Minitest::Test
     env = { "PATH" => "#{@fake_bin}:#{ENV.fetch("PATH")}" }
     stdout, stderr, status = Open3.capture3(env, RbConfig.ruby, File.join(@repo_root, "bin", "malt.rb"), "start", "--config", config_path, chdir: outside_dir)
 
-    assert status.success?, stderr
+    # The PHP-FPM config file is missing, so start reports failure with a non-zero exit
+    refute status.success?, stderr
     refute_includes stderr, File.join(outside_dir, "malt")
+    assert_includes stderr, "Failed to start: PHP-FPM"
     assert_includes stdout, File.join(project_dir, "malt", "conf", "php-fpm_19090.conf")
   end
 

--- a/test/services/scoped_lifecycle_test.rb
+++ b/test/services/scoped_lifecycle_test.rb
@@ -155,6 +155,8 @@ class ScopedLifecycleTest < Minitest::Test
 
   def setup
     @temp_dir = Dir.mktmpdir("malt lifecycle test")
+    @saved_registry_dir = ENV["MALT_REGISTRY_DIR"]
+    ENV["MALT_REGISTRY_DIR"] = File.join(@temp_dir, "registry")
     @config_path = File.join(@temp_dir, "malt.json")
     File.write(@config_path, JSON.generate({
       "project_name" => "lifecycle_test",
@@ -175,6 +177,7 @@ class ScopedLifecycleTest < Minitest::Test
   end
 
   def teardown
+    ENV["MALT_REGISTRY_DIR"] = @saved_registry_dir
     FileUtils.rm_rf(@temp_dir)
   end
 


### PR DESCRIPTION
## Summary
- `malt kill` now only SIGKILLs processes recorded in a shared pid registry (`HOMEBREW_PREFIX/var/malt/pids/`), verifying each pid's live command line against the pattern recorded at start time before killing it — foreign/Homebrew-managed processes can no longer be touched
- `malt status` becomes pid-based, distinguishing `running` / `stopped` / `external process on port`
- `malt start` now exits non-zero when any service fails to start
- php ports are no longer required for non-PHP projects
- Updated CLAUDE.md/AGENTS.md to document the pid registry and the removed php-ports requirement

## Test plan
- [x] `rake test` (83 runs, 0 failures, 0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added reliable service status tracking and safer process management.
  - `malt start` now reports startup failures with a non-zero exit status.
  - Service logs are redirected to per-service log files.
  - External processes occupying service ports are distinguished from managed services.
  - PHP configuration is optional when PHP is not configured.
  - Added static-only web server configurations for projects without PHP.

- **Bug Fixes**
  - Improved cleanup of stale or stopped service processes.
  - Prevented termination of unrelated processes during forced shutdown.

- **Documentation**
  - Expanded development, troubleshooting, CLI, and service-management guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->